### PR TITLE
Remove unused g_calls in FlpGeneric.prove

### DIFF
--- a/poc/flp_generic.sage
+++ b/poc/flp_generic.sage
@@ -200,7 +200,7 @@ class FlpGeneric(Flp):
 
         # Construct the proof.
         proof = []
-        for (g, g_calls) in zip(valid.GADGETS, valid.GADGET_CALLS):
+        for g in valid.GADGETS:
             P = len(g.wire[0])
 
             # Compute the wire polynomials for this gadget.


### PR DESCRIPTION
As far as I can tell this is an unnecessary zip, as `g_calls` is unused in this scope