### PR TITLE
poc: Add VerifyParam type annotation to Prio3

### DIFF
--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -22,6 +22,7 @@ class Prio3(Vdaf):
     SHARES = None  # provided by instantiation (a number between `[0, 255)`)
 
     # Types required by `Vdaf`
+    VerifyParam = Tuple[Unsigned, Bytes]
     Measurement = Flp.Measurement
     OutShare = Vec[Flp.Field]
     AggShare = Vec[Flp.Field]


### PR DESCRIPTION
I'm not certain that this is correct, but it seems like `VerifyParam` isn't the `Vdaf` default of `None` for `Prio3`