### PR TITLE
editorial: Replace double quotes with single quotes

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -431,8 +431,8 @@ types enumerated in the following table.
 ## Sharding {#sec-daf-shard}
 
 In order to protect the privacy of its measurements, a DAF Client shards its
-measurements into a sequence of "input shares".  The
-`measurement_to_input_shares` method is used for this purpose.
+measurements into a sequence of input shares. The `measurement_to_input_shares`
+method is used for this purpose.
 
 * `Daf.measurement_to_input_shares(input: Measurement) -> Vec[Bytes]` is the
   randomized input-distribution algorithm run by each Client. It consumes the
@@ -1071,7 +1071,7 @@ class PrgAes128:
 
 > NOTE This construction has not undergone significant security analysis.
 
-This section describes "Prio3", a VDAF for Prio {{CGB17}}. Prio is suitable for
+This section describes Prio3, a VDAF for Prio {{CGB17}}. Prio is suitable for
 a wide variety of aggregation functions, including (but not limited to) sum,
 mean, standard deviation, estimation of quantiles (e.g., median), and linear
 regression. In fact, the scheme described in this section is compatible with any
@@ -1099,7 +1099,7 @@ This VDAF does not have an aggregation parameter. Instead, the output share is
 derived from the input share by applying a fixed map. See {{poplar1}} for an
 example of a VDAF that makes meaningful use of the aggregation parameter.
 
-As the name implies, "Prio3" is a descendant of the original Prio construction.
+As the name implies, Prio3 is a descendant of the original Prio construction.
 A second iteration was deployed in the {{ENPA}} system, and like the VDAF
 described here, the ENPA system was built from techniques introduced in
 {{BBCGGI19}} that significantly improve communication cost. That system was
@@ -1174,11 +1174,11 @@ validity (encoding is described below in {{flp-encode}}):
 Our application requires that the FLP is "fully linear" in the sense defined in
 {{BBCGGI19}} As a practical matter, what this property implies is that, when run
 on a share of the input and proof, the query-generation algorithm outputs a
-share of the verifier message. Furthermore, the "zero-knowledge" property of the
-FLP system ensures that the verifier message reveals nothing about the input's
-validity. Therefore, to decide if an input is valid, the Aggregators will run
-the query-generation algorithm locally, exchange verifier shares, combine
-them to recover the verifier message, and run the decision algorithm.
+share of the verifier message. Furthermore, the "strong zero-knowledge" property
+of the FLP system ensures that the verifier message reveals nothing about the
+input's validity. Therefore, to decide if an input is valid, the Aggregators
+will run the query-generation algorithm locally, exchange verifier shares,
+combine them to recover the verifier message, and run the decision algorithm.
 
 An FLP is executed by the prover and verifier as follows:
 
@@ -1282,7 +1282,7 @@ are described in {{prio3-helper-functions}}.
 ~~~
 def measurement_to_input_shares(Prio3, measurement):
     # Domain separation tag for PRG info string
-    dst = b"vdaf-00 prio3"
+    dst = b'vdaf-00 prio3'
     inp = Prio3.Flp.encode(measurement)
     k_joint_rand = zeros(Prio3.Prg.SEED_SIZE)
 
@@ -1399,7 +1399,7 @@ make use of encoding and decoding methods defined in {{prio3-helper-functions}}.
 ~~~
 def prep_init(Prio3, verify_key, agg_id, _agg_param, nonce, input_share):
     # Domain separation tag for PRG info string
-    dst = b"vdaf-00 prio3"
+    dst = b'vdaf-00 prio3'
 
     (input_share, proof_share, k_blind, k_hint) = \
         Prio3.decode_leader_share(input_share) if agg_id == 0 else \
@@ -1655,7 +1655,7 @@ To make this work, the proof system is restricted to validity circuits that
 exhibit a special structure. Specifically, an arithmetic circuit with "G-gates"
 (see {{BBCGGI19}}, Definition 5.2) is composed of affine gates and any number of
 instances of a distinguished gate `G`, which may be non-affine. We will refer to
-this class of circuits as "gadget circuits" and to `G` as the "gadget".
+this class of circuits as 'gadget circuits' and to `G` as the "gadget".
 
 As an illustrative example, consider a validity circuit `C` that recognizes the
 set `L = set([0], [1])`. That is, `C` takes as input a length-1 vector `x` and
@@ -2331,14 +2331,14 @@ class PrepState:
      self.correlation_shares) = decode_input_share(input_share)
     (self.party_id, k_verify_init) = verify_param
     self.k_verify_rand = get_key(k_verify_init, nonce)
-    self.step = "ready"
+    self.step = 'ready'
 
   def next(self, inbound: Optional[Bytes]):
     l = self.l
     (a_share, b_share, c_share,
      A_share, B_share) = correlation_shares[l-1]
 
-    if self.step == "ready" and inbound == None:
+    if self.step == 'ready' and inbound == None:
       # Evaluate IDPF on candidate prefixes.
       data_share, auth_share = [], []
       for x in self.candidate_prefixes:
@@ -2355,10 +2355,10 @@ class PrepState:
       ]
 
       self.output_share = data_share
-      self.step = "sketch round 1"
+      self.step = 'sketch round 1'
       return verifier_share_1
 
-    elif self.step == "sketch round 1" and inbound != None:
+    elif self.step == 'sketch round 1' and inbound != None:
       verifier_1 = Field[l].decode_vec(inbound)
       verifier_share_2 = [
         (verifier_1[0] * verifier_1[0] \
@@ -2368,10 +2368,10 @@ class PrepState:
         + B_share
       ]
 
-      self.step = "sketch round 2"
+      self.step = 'sketch round 2'
       return Field[l].encode_vec(verifier_share_2)
 
-    elif self.step == "sketch round 2" and inbound != None:
+    elif self.step == 'sketch round 2' and inbound != None:
       verifier_2 = Field[l].decode_vec(inbound)
       if verifier_2 != 0: raise ERR_INVALID
       return Field[l].encode_vec(self.output_share)

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -11,9 +11,9 @@ TEST_VECTOR = False
 
 # Document version, reved with each new draft.
 #
-# NOTE The CFRG has not yet adopted this spec. Version "vdaf-00" will match
+# NOTE The CFRG has not yet adopted this spec. Version 'vdaf-00' will match
 # draft-irtf-cfrg-vdaf-00.
-VERSION = b"vdaf-00"
+VERSION = b'vdaf-00'
 
 
 # Primitive types
@@ -30,11 +30,11 @@ class Error(BaseException):
 
 
 # Errors
-ERR_ABORT = Error("algorithm aborted")
-ERR_DECODE = Error("decode failure")
-ERR_ENCODE = Error("encode failure")
-ERR_INPUT = Error("invalid input parameter")
-ERR_VERIFY = Error("verification of the user's input failed")
+ERR_ABORT = Error('algorithm aborted')
+ERR_DECODE = Error('decode failure')
+ERR_ENCODE = Error('encode failure')
+ERR_INPUT = Error('invalid input parameter')
+ERR_VERIFY = Error('verification of the user\'s input failed')
 
 
 # Return the smallest power of 2 that is larger than or equal to n.
@@ -82,13 +82,13 @@ def vec_add(left, right):
 def I2OSP(val, length):
     val = int(val)
     if val < 0 or val >= (1 << (8 * length)):
-        raise ValueError("bad I2OSP call: val=%d length=%d" % (val, length))
+        raise ValueError('bad I2OSP call: val=%d length=%d' % (val, length))
     ret = [0] * length
     val_ = val
     for idx in reversed(range(0, length)):
         ret[idx] = val_ & 0xff
         val_ = val_ >> 8
-    ret = struct.pack("=" + "B" * length, *ret)
+    ret = struct.pack('=' + 'B' * length, *ret)
     assert OS2IP(ret, True) == val
     return ret
 
@@ -100,7 +100,7 @@ def I2OSP(val, length):
 # it, similar to what the voprf draft does.
 def OS2IP(octets, skip_assert=False):
     ret = 0
-    for octet in struct.unpack("=" + "B" * len(octets), octets):
+    for octet in struct.unpack('=' + 'B' * len(octets), octets):
         ret = ret << 8
         ret += octet
     if not skip_assert:

--- a/poc/daf.sage
+++ b/poc/daf.sage
@@ -32,7 +32,7 @@ class Daf:
     @classmethod
     def measurement_to_input_shares(Daf,
                                     measurement: Measurement) -> Vec[Bytes]:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Prepare an input share for aggregation. This algorithm takes as input an
     # Aggregator's input share and an aggreation parameter and returns the
@@ -41,7 +41,7 @@ class Daf:
     def prep(Daf,
              agg_param: AggParam,
              input_share: Bytes) -> OutShare:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Merge a list of output shares into an aggregate share. This is called by
     # an Aggregator after recovering a batch of output shares.
@@ -49,7 +49,7 @@ class Daf:
     def out_shares_to_agg_share(Daf,
                                 agg_param: AggParam,
                                 out_shares: Vec[OutShare]) -> AggShare:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Unshard the aggregate shares and compute the aggregate result. This is
     # called by the Collector.
@@ -57,13 +57,13 @@ class Daf:
     def agg_shares_to_result(Daf,
                              agg_param: AggParam,
                              agg_shares: Vec[AggShare]) -> AggResult:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Returns a printable version of the verification parameters. This is used
     # for test vector generation.
     @classmethod
     def test_vector_verify_params(Daf, verify_params: Vec[VerifyParam]):
-        raise Error("not implemented")
+        raise Error('not implemented')
 
 
 # Run a DAF on a list of measurements.
@@ -149,9 +149,9 @@ def test_daf(cls,
                          agg_param,
                          measurements)
     if agg_result != expected_agg_result:
-        print("vdaf test failed ({} on {}): unexpected result: got {}; want {}".format(
+        print('vdaf test failed ({} on {}): unexpected result: got {}; want {}'.format(
             cls, measurements, agg_result, expected_agg_result))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     test_daf(DafTest, None, [1, 2, 3, 4], [10])

--- a/poc/field.sage
+++ b/poc/field.sage
@@ -24,7 +24,7 @@ class Field:
 
     @classmethod
     def gen(cls) -> Field:
-        raise Error("gen() not implemented")
+        raise Error('gen() not implemented')
 
     @classmethod
     def zeros(cls, length: Unsigned) -> Vec[Field]:
@@ -170,7 +170,7 @@ def poly_eval(Field, p, eval_at):
 
 # Compute the Lagrange interpolation polynomial for the given points.
 def poly_interp(Field, xs, ys):
-    R = PolynomialRing(Field.gf, "x")
+    R = PolynomialRing(Field.gf, 'x')
     p = R.lagrange_polynomial([(x.val, y.val) for (x, y) in zip(xs, ys)])
     return poly_strip(Field, list(map(lambda x: Field(x), p.coefficients())))
 
@@ -211,7 +211,7 @@ def test_field(cls):
     assert cls.gen()^cls.GEN_ORDER == cls(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     test_field(Field64)
     test_field(Field96)
     test_field(Field128)

--- a/poc/flp.sage
+++ b/poc/flp.sage
@@ -36,7 +36,7 @@ class Flp:
     # Encode a measurement as an input.
     @classmethod
     def encode(Flp, measurement: Measurement) -> Vec[Field]:
-        raise Error("encode() not implemented")
+        raise Error('encode() not implemented')
 
     # Generate a proof of an input's validity.
     @classmethod
@@ -44,7 +44,7 @@ class Flp:
               inp: Vec[Field],
               prove_rand: Vec[Field],
               joint_rand: Vec[Field]) -> Vec[Field]:
-        raise Error("prove() not implemented")
+        raise Error('prove() not implemented')
 
     # Generate a verifier message for an input and proof.
     @classmethod
@@ -54,17 +54,17 @@ class Flp:
               query_rand: Vec[Field],
               joint_rand: Vec[Field],
               num_shares: Unsigned) -> Vec[Field]:
-        raise Error("query() not implemented")
+        raise Error('query() not implemented')
 
     # Decide if a verifier message was generated from a valid input.
     @classmethod
     def decide(Flp, verifier: Vec[Field]) -> Bool:
-        raise Error("decide() not implemented")
+        raise Error('decide() not implemented')
 
     #  Map an input to an aggregatable output.
     @classmethod
     def truncate(Flp, inp: Vec[Field]) -> Vec[Field]:
-        raise Error("truncate() not implemented")
+        raise Error('truncate() not implemented')
 
 
 # Run the FLP on an input.
@@ -146,7 +146,7 @@ class FlpTestField128(FlpTest):
         return new_cls
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cls = FlpTestField128
     assert run_flp(cls, cls.encode(0), 1) == True
     assert run_flp(cls, cls.encode(4), 1) == True

--- a/poc/flp_generic.sage
+++ b/poc/flp_generic.sage
@@ -18,11 +18,11 @@ class Gadget:
 
     # Evaluate the gadget on a sequence of field elements.
     def eval(self, Field, inp):
-        raise Error("eval() not implemented")
+        raise Error('eval() not implemented')
 
     # Evaluate the gadget on a sequence of polynomials over a fieldo.
     def eval_poly(self, Field, inp_poly):
-        raise Error("eval_poly() not implemented")
+        raise Error('eval_poly() not implemented')
 
 # A validity circuit.
 class Valid:
@@ -76,19 +76,19 @@ class Valid:
     # Encode a measurement as an input.
     @classmethod
     def encode(Valid, measurement: Measurement) -> Vec[Field]:
-        raise Error("encode() not implemented")
+        raise Error('encode() not implemented')
 
     # Truncate an input to the length of an aggregatable output.
     @classmethod
     def truncate(Valid, inp: Vec[Field]) -> Vec[Field]:
-        raise Error("truncate() not implemented")
+        raise Error('truncate() not implemented')
 
     # Evaluate the circuit on the provided input and joint randomness.
     def eval(self,
              inp: Vec[Field],
              joint_rand: Vec[Field],
              num_shares: Unsigned):
-        raise Error("eval() not implemented")
+        raise Error('eval() not implemented')
 
 
 class ProveGadget:
@@ -356,7 +356,7 @@ class PolyEval(Gadget):
                 break
 
         if len(p) < 1:
-            raise Error("invalid polynomial: zero length")
+            raise Error('invalid polynomial: zero length')
 
         self.p = p
         self.DEGREE = len(p) - 1
@@ -445,7 +445,7 @@ class Sum(Valid):
     @classmethod
     def with_bits(cls, bits):
         if 2^bits >= cls.Field.MODULUS:
-            raise Error("bit size exceeds field modulus")
+            raise Error('bit size exceeds field modulus')
 
         new_cls = deepcopy(cls)
         new_cls.GADGET_CALLS = [bits]
@@ -574,16 +574,16 @@ def test_flp_generic(cls, test_cases):
         joint_rand = cls.Field.rand_vec(cls.JOINT_RAND_LEN)
         v = cls.Valid().eval(inp, joint_rand, 1)
         if (v == cls.Field(0)) != expected_decision:
-            print("{}: test {} failed: validity circuit returned {}".format(
+            print('{}: test {} failed: validity circuit returned {}'.format(
                 cls.Valid.__name__, i, v))
 
         # Run the FLP.
         decision = run_flp(cls, inp, 1)
         if decision != expected_decision:
-            print("{}: test {} failed: proof evaluation resulted in {}; want {}".format(
+            print('{}: test {} failed: proof evaluation resulted in {}; want {}'.format(
                 cls.Valid.__name__, i, decision, expected_decision))
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cls = FlpGeneric.with_valid(Count)
     test_flp_generic(cls, [
         (cls.encode(0), True),

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -24,11 +24,11 @@ class Prg:
 
     # Construct a new instnace of this PRG from the given seed and info string.
     def __init__(self, seed: Bytes, info: Bytes) -> Prg:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Output the next `length` bytes of the PRG stream.
     def next(self, length: Unsigned) -> Bytes:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Derive a new seed.
     @classmethod
@@ -81,7 +81,7 @@ class PrgAes128(Prg):
 #
 
 def test_prg(Prg, F, expanded_len):
-    info = b"info string"
+    info = b'info string'
     seed = gen_rand(Prg.SEED_SIZE)
 
     # Test next
@@ -89,7 +89,7 @@ def test_prg(Prg, F, expanded_len):
     assert len(expanded_data) == expanded_len
 
     want = Prg(seed, info).next(700)
-    got = b""
+    got = b''
     prg = Prg(seed, info)
     for i in range(0, 700, 7):
         got += prg.next(7)
@@ -104,7 +104,7 @@ def test_prg(Prg, F, expanded_len):
     assert len(expanded_vec) == expanded_len
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import json
     from sagelib.field import Field128
 
@@ -112,21 +112,21 @@ if __name__ == "__main__":
     test_prg(cls, Field128, 23)
     if TEST_VECTOR:
         seed = gen_rand(cls.SEED_SIZE)
-        info = b"info string"
+        info = b'info string'
         length = 40
 
         test_vector = {
-            "seed": seed.hex(),
-            "info": info.hex(),
-            "length": int(length),
-            "derived_seed": None, # set below
-            "expanded_vec": None, # set below
+            'seed': seed.hex(),
+            'info': info.hex(),
+            'length': int(length),
+            'derived_seed': None, # set below
+            'expanded_vec': None, # set below
         }
 
-        test_vector["derived_seed"] = cls.derive_seed(seed, info).hex()
-        test_vector["expanded_vec"] = Field128.encode_vec(
+        test_vector['derived_seed'] = cls.derive_seed(seed, info).hex()
+        test_vector['expanded_vec'] = Field128.encode_vec(
                 cls.expand_into_vec(Field128, seed, info, length)).hex()
 
-        print("--- {} ({}) ----------------------------".format(cls, Field128))
+        print('--- {} ({}) ----------------------------'.format(cls, Field128))
         print(json.dumps(test_vector, indent=4))
         print()

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -43,7 +43,7 @@ class Vdaf:
     @classmethod
     def measurement_to_input_shares(Vdaf,
                                     measurement: Measurement) -> Vec[Bytes]:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Initialize the Prepare state for the given input share. This method is run
     # by an Aggregator. Along with the input share, the inputs include the
@@ -57,7 +57,7 @@ class Vdaf:
                   agg_param: AggParam,
                   nonce: Bytes,
                   input_share: Bytes) -> Prep:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Consume the inbound message from the previous round (or `None` if this is
     # the first round) and return the aggregator's share of the next round (or
@@ -67,7 +67,7 @@ class Vdaf:
                   prep: Prep,
                   inbound: Optional[Bytes],
                   ) -> Union[Tuple[Prep, Bytes], Vdaf.OutShare]:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Unshard the Prepare message shares from the previous round of the Prapare
     # computation. This is called by an aggregator after receiving all of the
@@ -77,7 +77,7 @@ class Vdaf:
     def prep_shares_to_prep(Vdaf,
                             agg_param: AggParam,
                             prep_shares: Vec[Bytes]) -> Bytes:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Merge a list of output shares into an aggregate share. This is called by
     # an aggregator after recovering a batch of output shares.
@@ -85,7 +85,7 @@ class Vdaf:
     def out_shares_to_agg_share(Vdaf,
                                 agg_param: AggParam,
                                 out_shares: Vec[OutShare]) -> AggShare:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
     # Unshard the aggregate shares and compute the aggregate result. This is
     # called by the ccollector.
@@ -93,7 +93,7 @@ class Vdaf:
     def agg_shares_to_result(Vdaf,
                              agg_param: AggParam,
                              agg_shares: Vec[AggShare]) -> AggResult:
-        raise Error("not implemented")
+        raise Error('not implemented')
 
 
 # Run the VDAF on a list of measurements.
@@ -108,27 +108,27 @@ def run_vdaf(Vdaf,
     verify_key = gen_rand(Vdaf.VERIFY_KEY_SIZE)
 
     test_vector = {
-        "verify_key": verify_key.hex(),
-        "agg_param": agg_param,
-        "prep": [],
-        "agg_shares": [],
-        "agg_result": None, # set below
+        'verify_key': verify_key.hex(),
+        'agg_param': agg_param,
+        'prep': [],
+        'agg_shares': [],
+        'agg_result': None, # set below
     }
     out_shares = []
     for (nonce, measurement) in zip(nonces, measurements):
 
         prep_test_vector = {
-            "measurement": int(measurement),
-            "nonce": nonce.hex(),
-            "input_shares": [],
-            "prep_shares": [[] for _ in range(Vdaf.ROUNDS)],
-            "out_shares": [],
+            'measurement': int(measurement),
+            'nonce': nonce.hex(),
+            'input_shares': [],
+            'prep_shares': [[] for _ in range(Vdaf.ROUNDS)],
+            'out_shares': [],
         }
 
         # Each Client shards its measurement into input shares.
         input_shares = Vdaf.measurement_to_input_shares(measurement)
         for input_share in input_shares:
-            prep_test_vector["input_shares"].append(input_share.hex())
+            prep_test_vector['input_shares'].append(input_share.hex())
 
         # Each Aggregator initializes its preparation state.
         prep_states = []
@@ -152,15 +152,15 @@ def run_vdaf(Vdaf,
             # network in a distributed VDAF computation.
             if i < Vdaf.ROUNDS:
                 for prep_share in outbound:
-                    prep_test_vector["prep_shares"][i].append(prep_share.hex())
+                    prep_test_vector['prep_shares'][i].append(prep_share.hex())
                 inbound = Vdaf.prep_shares_to_prep(agg_param,
                                                    outbound)
 
         # The final outputs of prepare phasre are the output shares.
         for out_share in outbound:
-            prep_test_vector["out_shares"].append(
+            prep_test_vector['out_shares'].append(
                 list(map(lambda x: x.as_unsigned(), out_share)))
-        test_vector["prep"].append(prep_test_vector)
+        test_vector['prep'].append(prep_test_vector)
         out_shares.append(outbound)
 
     # Each Aggregator aggregates its output shares into an
@@ -171,15 +171,15 @@ def run_vdaf(Vdaf,
         agg_share_j = Vdaf.out_shares_to_agg_share(agg_param,
                                                    out_shares_j)
         agg_shares.append(agg_share_j)
-        test_vector["agg_shares"].append(
+        test_vector['agg_shares'].append(
             list(map(lambda x: x.as_unsigned(), agg_share_j)))
 
     # Collector unshards the aggregate.
     agg_result = Vdaf.agg_shares_to_result(agg_param, agg_shares)
-    test_vector["agg_result"] = list(map(lambda x: int(x), agg_result))
+    test_vector['agg_result'] = list(map(lambda x: int(x), agg_result))
 
     if print_test_vector:
-        print("---- {} -----------------------------".format(Vdaf))
+        print('---- {} -----------------------------'.format(Vdaf))
         print(json.dumps(test_vector, indent=4))
         print()
     return agg_result
@@ -277,9 +277,9 @@ def test_vdaf(cls,
                           measurements,
                           print_test_vector)
     if agg_result != expected_agg_result:
-        print("vdaf test failed ({} on {}): unexpected result: got {}; want {}".format(
+        print('vdaf test failed ({} on {}): unexpected result: got {}; want {}'.format(
             cls, measurements, agg_result, expected_agg_result))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     test_vdaf(VdafTest, None, [1, 2, 3, 4], [10])

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -33,7 +33,7 @@ class Prio3(Vdaf):
 
     @classmethod
     def measurement_to_input_shares(Prio3, measurement):
-        dst = VERSION + b" prio3"
+        dst = VERSION + b' prio3'
         inp = Prio3.Flp.encode(measurement)
         k_joint_rand = zeros(Prio3.Prg.SEED_SIZE)
 
@@ -118,7 +118,7 @@ class Prio3(Vdaf):
     # randomness directly.
     @classmethod
     def prep_init(Prio3, verify_key, agg_id, _agg_param, nonce, input_share):
-        dst = VERSION + b" prio3"
+        dst = VERSION + b' prio3'
 
         (input_share, proof_share, k_blind, k_hint) = \
             Prio3.decode_leader_share(input_share) if agg_id == 0 else \
@@ -366,7 +366,7 @@ class Prio3Aes128Histogram(Prio3):
 # TESTS
 #
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cls = Prio3 \
         .with_prg(prg.PrgAes128) \
         .with_flp(flp.FlpTestField128) \


### PR DESCRIPTION
Backticks get rendered as double quotes in the plaintext version,
potentially colliding with byte string literals in the spec, e.g.:

    "b"vdaf-00""

By using single quotes, we ensure this gets rendored instead as

    "b'vdaf'00'"

which is a bit clearer.

We may want to consider removing backticks altogether.