### PR TITLE
Define codepoints for (V)DAFs

### DIFF
--- a/poc/daf.sage
+++ b/poc/daf.sage
@@ -9,6 +9,9 @@ import json
 # A DAF
 class Daf:
 
+    # Algorithm identifier for this DAF, a 32-bit integer.
+    ID: Unsigned = None
+
     # The number of Aggregators.
     SHARES: Unsigned = None
 
@@ -111,6 +114,7 @@ class TestDaf(Daf):
     Field = field.Field128
 
     # Associated parameters
+    ID = 0xFFFFFFFF
     SHARES = 2
 
     # Associated types
@@ -151,16 +155,20 @@ class TestDaf(Daf):
         pass
 
 
-def test_daf(cls,
+def test_daf(Daf,
              agg_param,
              measurements,
              expected_agg_result):
-    agg_result = run_daf(cls,
+    # Test that the algorithm identifier is in the correct range.
+    assert 0 <= Daf.ID and Daf.ID < 2^32
+
+    # Run the DAF on the set of measurements.
+    agg_result = run_daf(Daf,
                          agg_param,
                          measurements)
     if agg_result != expected_agg_result:
         print('vdaf test failed ({} on {}): unexpected result: got {}; want {}'.format(
-            cls, measurements, agg_result, expected_agg_result))
+            Daf.__classname__, measurements, agg_result, expected_agg_result))
 
 
 if __name__ == '__main__':

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -13,6 +13,9 @@ import os
 # A VDAF.
 class Vdaf:
 
+    # Algorithm identifier for this VDAF, a 32-bit integer.
+    ID: Unsigned = None
+
     # Length of the verification key shared by the Aggregators.
     VERIFY_KEY_SIZE = None
 
@@ -273,6 +276,7 @@ class TestVdaf(Vdaf):
     Field = field.Field128
 
     # Associated parameters
+    ID = 0xFFFFFFFF
     VERIFY_KEY_SIZE = 0
     SHARES = 2
     ROUNDS = 1
@@ -351,15 +355,19 @@ class TestVdaf(Vdaf):
                 agg_shares))[0].as_unsigned()]
 
 
-def test_vdaf(cls,
+def test_vdaf(Vdaf,
               agg_param,
               measurements,
               expected_agg_result,
               print_test_vec=False,
               test_vec_instance=0):
-    # The nonces need not be random, but merely non-repeating.
+    # Test that the algorithm identifier is in the correct range.
+    assert 0 <= Vdaf.ID and Vdaf.ID < 2^32
+
+    # Run the VDAF on the set of measurmenets. Note that the nonces need not be
+    # random, but merely non-repeating.
     nonces = [gen_rand(16) for _ in range(len(measurements))]
-    agg_result = run_vdaf(cls,
+    agg_result = run_vdaf(Vdaf,
                           agg_param,
                           nonces,
                           measurements,
@@ -367,7 +375,7 @@ def test_vdaf(cls,
                           test_vec_instance)
     if agg_result != expected_agg_result:
         print('vdaf test failed ({} on {}): unexpected result: got {}; want {}'.format(
-            cls.__name__, measurements, agg_result, expected_agg_result))
+            Vdaf.__name__, measurements, agg_result, expected_agg_result))
 
 
 if __name__ == '__main__':

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -17,6 +17,7 @@ class Poplar1(Vdaf):
     Idpf = idpf.Idpf
 
     # Parameters required by `Vdaf`.
+    ID = 0x00001000
     VERIFY_KEY_SIZE = None # Set by Idpf.Prg
     SHARES = 2
     ROUNDS = 2
@@ -34,7 +35,7 @@ class Poplar1(Vdaf):
 
     @classmethod
     def measurement_to_input_shares(Poplar1, measurement):
-        dst = VERSION + b' poplar1'
+        dst = VERSION + I2OSP(Poplar1.ID, 4)
         prg = Poplar1.Idpf.Prg(
             gen_rand(Poplar1.Idpf.Prg.SEED_SIZE), dst + byte(255))
 
@@ -96,7 +97,7 @@ class Poplar1(Vdaf):
     @classmethod
     def prep_init(Poplar1, verify_key, agg_id, agg_param,
                   nonce, public_share, input_share):
-        dst = VERSION + b' poplar1'
+        dst = VERSION + I2OSP(Poplar1.ID, 4)
         (level, prefixes) = agg_param
         (key, corr_seed, corr_inner, corr_leaf) = \
             Poplar1.decode_input_share(input_share)
@@ -379,6 +380,7 @@ if __name__ == '__main__':
 
     # Generate test vectors.
     cls = Poplar1Aes128.with_bits(4)
+    assert cls.ID == 0x00001000
     measurements = [0b1101]
     tests = [
         # (level, prefixes, expected result)


### PR DESCRIPTION
Partially addresses #102.

Each (V)DAF defines a 32-bit codepoint used to uniquely identify it. The
current scheme is as follows:

* The first 3 nibbles are used to identify the VDAF "class", e.g.,
  Prio3Aes128 or Poplar1Aes128.
* The remaining 5 nibbles are reserved for particular "instances",
  e.g., Prio3Aes128Count, Prio3Aes128Sum, etc.

While at it, incorporate the codepoints into domain separation tags
(DSTs) in Prio3 and Poplar1. This is needed primarily for Prio3. (See
issue#102.)