### PR TITLE
Prio3: Align spec with revised paper

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -283,7 +283,7 @@ security considerations for VDAFs.
 
 ## Change Log
 
-(*) Indicates a change that breaks wire compatibility with the previous draft.
+(\*) Indicates a change that breaks wire compatibility with the previous draft.
 
 02:
 

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -1,9 +1,9 @@
 # Functionalities used by other modules.
 
+from functools import reduce
 from typing import List, TypeVar
-
-import struct
 import os
+import struct
 
 
 # If set, then test vectors will be generated. A fixed source of randomness is
@@ -109,6 +109,10 @@ def OS2IP(octets, skip_assert=False):
     if not skip_assert:
         assert octets == I2OSP(ret, len(octets))
     return ret
+
+# Return the concatenated byte strings.
+def concat(strings: Vec[Bytes]) -> Bytes:
+    return reduce(lambda x, y: x + y, strings)
 
 def print_wrapped_line(line, tab):
     width=72

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -111,8 +111,8 @@ def OS2IP(octets, skip_assert=False):
     return ret
 
 # Return the concatenated byte strings.
-def concat(strings: Vec[Bytes]) -> Bytes:
-    return reduce(lambda x, y: x + y, strings)
+def concat(parts: Vec[Bytes]) -> Bytes:
+    return reduce(lambda x, y: x + y, parts)
 
 def print_wrapped_line(line, tab):
     width=72


### PR DESCRIPTION
Partially addresses #102.

A bug was found in [BBCGGI+19] that leads to an attack on the robustness
of Prio3. The attack is based on an observation in Appendix A of the
paper "A New Paradigm for Collision-Free Hashing: Incrementality at
Reduced Cost" from Bellare and Micciancio (Eurocrypt 1997). In short,
the attack allows a malicious Client to construct invalid input shares
for which the Aggregators would compute a `k_joint_rand` of its
choosing.

This bug was patched in Section 6.2.3 of
https://eprint.iacr.org/archive/2019/188/20220727:184451 as follows:
Instead of XORing joint randomness shares computed by the
Aggregators, `k_joint_rand` is computed by hashing the shares. This
change patches the Prio3 spec in kind.