### PR TITLE
Add nonces to VDAF sharding syntax & Prio3

### DIFF
--- a/poc/README.md
+++ b/poc/README.md
@@ -2,11 +2,11 @@
 
 This directory contains SageMath implementations of VDAFs. This code is used to
 generate test vectors as well as the algorithm definitions in the document
-themesleves.
+themselves.
 
 ## Installation
 
-This code is compatilbe with SageMath version 9.6.
+This code is compatible with SageMath version 9.6.
 
 In order to run the code you will need to install
 [PyCryptodome](https://pycryptodome.readthedocs.io/en/latest/index.html).

--- a/poc/README.md
+++ b/poc/README.md
@@ -2,11 +2,11 @@
 
 This directory contains SageMath implementations of VDAFs. This code is used to
 generate test vectors as well as the algorithm definitions in the document
-themselves.
+themesleves.
 
 ## Installation
 
-This code is compatible with SageMath version 9.6.
+This code is compatilbe with SageMath version 9.6.
 
 In order to run the code you will need to install
 [PyCryptodome](https://pycryptodome.readthedocs.io/en/latest/index.html).

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -44,8 +44,8 @@ class Vdaf:
     # one for each Aggregator. This method is run by the Client.
     @classmethod
     def measurement_to_input_shares(Vdaf,
-                                    measurement: Measurement) -> (Bytes,
-                                                                  Vec[Bytes]):
+                                    measurement: Measurement,
+                                    nonce: Bytes) -> (Bytes, Vec[Bytes]):
         raise Error('not implemented')
 
     # Initialize the Prepare state for the given input share. This method is run
@@ -145,7 +145,7 @@ def run_vdaf(Vdaf,
 
         # Each Client shards its measurement into input shares.
         (public_share, input_shares) = \
-            Vdaf.measurement_to_input_shares(measurement)
+            Vdaf.measurement_to_input_shares(measurement, nonce)
 
         # REMOVE ME
         prep_test_vec['public_share'] = public_share.hex()
@@ -299,7 +299,7 @@ class TestVdaf(Vdaf):
         return (None, [None for _ in range(cls.SHARES)])
 
     @classmethod
-    def measurement_to_input_shares(cls, measurement):
+    def measurement_to_input_shares(cls, measurement, nonce):
         helper_shares = cls.Field.rand_vec(cls.SHARES-1)
         leader_share = cls.Field(measurement)
         for helper_share in helper_shares:

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -34,7 +34,7 @@ class Poplar1(Vdaf):
     AggResult = Vec[Unsigned]
 
     @classmethod
-    def measurement_to_input_shares(Poplar1, measurement):
+    def measurement_to_input_shares(Poplar1, measurement, _nonce):
         dst = VERSION + I2OSP(Poplar1.ID, 4)
         prg = Poplar1.Idpf.Prg(
             gen_rand(Poplar1.Idpf.Prg.SEED_SIZE), dst + byte(255))

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -31,7 +31,7 @@ class Prio3(Vdaf):
                  Bytes]           # outbound message
 
     @classmethod
-    def measurement_to_input_shares(Prio3, measurement):
+    def measurement_to_input_shares(Prio3, measurement, nonce):
         dst = VERSION + I2OSP(Prio3.ID, 4)
         inp = Prio3.Flp.encode(measurement)
 
@@ -53,14 +53,14 @@ class Prio3(Vdaf):
                                          helper_input_share)
             encoded = Prio3.Flp.Field.encode_vec(helper_input_share)
             k_joint_rand_part = Prio3.Prg.derive_seed(
-                k_blind, dst + byte(j+1) + encoded)
+                k_blind, dst + byte(j+1) + nonce + encoded)
             k_helper_input_shares.append(k_share)
             k_helper_blinds.append(k_blind)
             k_joint_rand_parts.append(k_joint_rand_part)
         k_leader_blind = gen_rand(Prio3.Prg.SEED_SIZE)
         encoded = Prio3.Flp.Field.encode_vec(leader_input_share)
         k_leader_joint_rand_part = Prio3.Prg.derive_seed(
-            k_leader_blind, dst + byte(0) + encoded)
+            k_leader_blind, dst + byte(0) + nonce + encoded)
         k_joint_rand_parts.insert(0, k_leader_joint_rand_part)
 
         # Compute joint randomness seed.
@@ -133,7 +133,7 @@ class Prio3(Vdaf):
         if Prio3.Flp.JOINT_RAND_LEN > 0:
             encoded = Prio3.Flp.Field.encode_vec(input_share)
             k_joint_rand_part = Prio3.Prg.derive_seed(
-                k_blind, dst + byte(agg_id) + encoded)
+                k_blind, dst + byte(agg_id) + nonce + encoded)
             k_joint_rand_parts = k_hint[:agg_id] + \
                                  [k_joint_rand_part] + \
                                  k_hint[agg_id:]


### PR DESCRIPTION
Closes #119.

I came across a concern about the robustness of Prio3.The construction uses a PRG to derive joint randomness from the input shares that is used by the client and all aggregators. If a client uploads the same set of input shares twice under distinct nonces, the aggregators will derive the same joint randomness in both preparation phases.Intuitively, this violates the expectation that the joint randomness is pseudorandom, or at least not completely controllable by an attacker. 
More formally, there is a degenerate FLP that is sound  with L bits of security when each set of input shares is submitted at most once, but is vulnerable to an 2^(L/2)-query attack if they can be submitted under many nonces. 

This PR mitigates the attack by including the nonce in the joint randomness derivation so that if input shares are submitted under two different nonces, they will go through preparation with independent joint randomness. It requires changing VDAF syntax so that Shard takes the nonce as input. There shouldn't be any change to communication as a result, and the operational cost to Prio3 is at worst 1 additional AES call per party.