### PR TITLE
Fix: Format test vector out shares as hex strings

### DIFF
--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -186,7 +186,7 @@ def run_vdaf(Vdaf,
         # REMOVE ME
         for out_share in outbound:
             prep_test_vec['out_shares'].append(
-                list(map(lambda x: x.as_unsigned(), out_share)))
+                list(map(lambda x: "{:x}".format(x.as_unsigned()), out_share)))
         test_vec['prep'].append(prep_test_vec)
 
         # The final outputs of prepare phase are the output shares.


### PR DESCRIPTION
Although large integers are not excluded from the json spec, many languages such as javascript do not correctly parse them into a type that can correctly represent these numbers. This commit changes those large integers into hex strings, as per #116.

Closes #116

Example change to the output json:
```diff
diff --git a/poc/test_vec/03/Prio3Aes128Histogram_0.json b/poc/test_vec/03/Prio3Aes128Histogram_0.json
index f5476455fa53ba563338721391f6f8d15f8c7f46..7bdfc4ef6e54edeed1c595be7cbe926e9cbeea30 100644
--- a/poc/test_vec/03/Prio3Aes128Histogram_0.json
+++ b/poc/test_vec/03/Prio3Aes128Histogram_0.json
@@ -25,16 +25,16 @@
             "nonce": "01010101010101010101010101010101",
             "out_shares": [
                 [
-                    316441748434879643753815489063091297628,
-                    208470253761472213750543248431791209107,
-                    245951175238245845331446316072865931791,
-                    133415875449384174923011884997795018199
+                    "ee1076c1ebc2d48a557a71031bc9dd5c",
+                    "9cd5e91180bbb51f4ac366946bcbfa93",
+                    "b908792bd15d402f4ac8da264e24a20f",
+                    "645ef68472180c5894bac704ae0675d7"
                 ],
                 [
-                    23840618486058819193050284304809468581,
-                    131812113159466249196322524936109557102,
-                    94331191682692617615419457295034834419,
-                    206866491471554288023853888370105748010
+                    "11ef893e143d2b59aa858efce43622a5",
+                    "632a16ee7f444ac4b53c996b9434056e",
+                    "46f786d42ea2bfb4b53725d9b1db5df3",
+                    "9ba1097b8de7f38b6b4538fb51f98a2a"
                 ]
             ],
             "prep_messages": [
```