### PR TITLE
Check unused bits when decoding IDPF public share

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3002,7 +3002,7 @@ def decode_public_share(IdpfPoplar, encoded):
         encoded_w_cw, encoded = encoded[:l], encoded[l:]
         w_cw = Field.decode_vec(encoded_w_cw)
         correction_words.append((seed_cw, ctrl_cw, w_cw))
-    if len(encoded) != 0:
+    if packed_ctrl != 0 or len(encoded) != 0:
         raise ERR_DECODE
     return correction_words
 ~~~

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -205,7 +205,7 @@ class IdpfPoplar(Idpf):
             encoded_w_cw, encoded = encoded[:l], encoded[l:]
             w_cw = Field.decode_vec(encoded_w_cw)
             correction_words.append((seed_cw, ctrl_cw, w_cw))
-        if len(encoded) != 0:
+        if packed_ctrl != 0 or len(encoded) != 0:
             raise ERR_DECODE
         return correction_words
 


### PR DESCRIPTION
This updates the IdpfPoplar public share decoding algorithm to check that any unused bits alongside the packed control bits are zero.