### PR TITLE
Use SHA-3 to instantiate the PRG and improve domain separation

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -29,6 +29,16 @@ author:
 
 normative:
 
+  SP800-185:
+    title: "SHA-3 Derived Functions: cSHAKE, KMAC, TupleHash and ParallelHash"
+    date: December 2016
+    seriesinfo: NIST Special Publication 800-185
+
+  FIPS202:
+    title: "SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions"
+    date: August 2015
+    seriesinfo: NIST FIPS PUB 202
+
 informative:
 
   AGJOP21:
@@ -354,8 +364,8 @@ A variable with type `Bytes` is a byte string. This document defines several
 byte-string constants. When comprised of printable ASCII characters, they are
 written as Python 3 byte-string literals (e.g., `b'some constant string'`).
 
-A global constant `VERSION` is defined, which algorithms are free to use as
-desired. Its value SHALL be `b'vdaf-03'`.
+A global constant `VERSION` of type `Unsigned` is defined, which algorithms are
+free to use as desired. Its value SHALL be `3`.
 
 This document describes algorithms for multi-party computations in which the
 parties typically communicate over a network. Wherever a quantity is defined
@@ -1135,8 +1145,7 @@ The tables below define finite fields used in the remainder of this document.
 
 A pseudorandom generator (PRG) is used to expand a short, (pseudo)random seed
 into a long string of pseudorandom bits. A PRG suitable for this document
-implements the interface specified in this section. Concrete constructions are
-described in the subsections that follow.
+implements the interface specified in this section.
 
 PRGs are defined by a class `Prg` with the following associated parameter:
 
@@ -1144,10 +1153,11 @@ PRGs are defined by a class `Prg` with the following associated parameter:
 
 A concrete `Prg` implements the following class method:
 
-* `Prg(seed: Bytes, info: Bytes)` constructs an instance of `Prg` from the given
-  seed and info string. The seed MUST be of length `SEED_SIZE` and MUST be
-  generated securely (i.e., it is either the output of `gen_rand` or a previous
-  invocation of the PRG). The info string is used for domain separation.
+* `Prg(seed: Bytes[Prg.SEED_SIZE], custom: Bytes, binder: Bytes)` constructs an
+  instance of `Prg` from the given seed and customization and binder strings.
+  (See below for definitions of these.) The seed MUST be of length `SEED_SIZE`
+  and MUST be generated securely (i.e., it is either the output of `gen_rand` or
+  a previous invocation of the PRG).
 
 * `prg.next(length: Unsigned)` returns the next `length` bytes of output of PRG.
   If the seed was securely generated, the output can be treated as pseudorandom.
@@ -1160,8 +1170,8 @@ pseudorandom field elements. For each method, the seed MUST be of length
 
 ~~~
 # Derive a new seed.
-def derive_seed(Prg, seed: Bytes, info: Bytes) -> bytes:
-    prg = Prg(seed, info)
+def derive_seed(Prg, seed: Bytes[Prg.SEED_SIZE], custom: Bytes, binder: Bytes):
+    prg = Prg(seed, custom, binder)
     return prg.next(Prg.SEED_SIZE)
 
 # Output the next `length` pseudorandom elements of `Field`.
@@ -1178,50 +1188,71 @@ def next_vec(self, Field, length: Unsigned):
 # Expand the input `seed` into vector of `length` field elements.
 def expand_into_vec(Prg,
                     Field,
-                    seed: Bytes,
-                    info: Bytes,
+                    seed: Bytes[Prg.SEED_SIZE],
+                    custom: Bytes,
+                    binder: Bytes,
                     length: Unsigned):
-    prg = Prg(seed, info)
+    prg = Prg(seed, custom, binder)
     return prg.next_vec(Field, length)
 ~~~
 {: #prg-derived-methods title="Derived class methods for PRGs."}
 
-### PrgAes128 {#prg-aes128}
+### PrgSha3 {#prg-sha3}
 
-> OPEN ISSUE Phillipp points out that a fixed-key mode of AES may be more
-> performant (https://eprint.iacr.org/2019/074.pdf). See issue#32.
-
-> TODO(issue #106) Decide if it's safe to model this construction as a random
-> oracle. `PrgAes128.derive_seed()` is used for the Fiat-Shamir heuristic in
-> Prio3 ({{prio3}}). A fixed-key is used for this step (the all-zero string). A
-> reasonable starting point would be to model AES as an ideal cipher.
-
-Our first construction, `PrgAes128`, converts a blockcipher, namely AES-128,
-into a PRG. Seed expansion involves two steps. In the first step, CMAC
-{{!RFC4493}} is applied to the seed and info string to get a fresh key. In the
-second step, the fresh key is used in CTR-mode to produce a key stream for
-generating the output. A fixed initialization vector (IV) is used.
+This section describes PrgSha3, a PRG based on the Keccak permutation of SHA-3
+{{FIPS202}}. Keccak is used in the cSHAKE128 mode of operation {{SP800-185}}.
 
 ~~~
-class PrgAes128:
+class PrgSha3(Prg):
+    # Associated parameters
+    SEED_SIZE = 16
 
-    SEED_SIZE: Unsigned = 16
+    def __init__(self, seed, custom, binder):
+        self.l = 0
+        self.x = seed + binder
+        self.s = custom
 
-    def __init__(self, seed, info):
-        self.length_consumed = 0
+    def next(self, length: Unsigned) -> Bytes:
+        self.l += length
 
-        # Use CMAC as a pseudorandom function to derive a key.
-        self.key = AES128-CMAC(seed, info)
-
-    def next(self, length):
-        self.length_consumed += length
-
-        # CTR-mode encryption of the all-zero string of the desired
-        # length and using a fixed, all-zero IV.
-        stream = AES128-CTR(key, zeros(16), zeros(self.length_consumed))
+        # Function `cSHAKE128(x, l, n, s)` is as defined in
+        # [SP800-185, Section 3.3].
+        #
+        # Implementation note: Rather than re-generate the output
+        # stream each time `next()` is invoked, most implementations
+        # of SHA-3 will expose an "absorb-then-squeeze" API that
+        # allows stateful handling of the stream.
+        stream = cSHAKE128(self.x, self.l, b'', self.s)
         return stream[-length:]
 ~~~
-{: title="Definition of PRG PrgAes128."}
+{: title="Definition of PRG PrgSha3."}
+
+### The Context and Binder Strings
+
+PRGs are used to map a seed to a finite domain, e.g., a fresh seed or a vector
+of field elements. To ensure domain separation, the derivation is needs to be
+bound to some distinguished "customization string". The customization string
+encodes the following values:
+
+1. The document version (i.e.,`VERSION`);
+1. The "class" of the algorithm using the output (e.g., VDAF);
+1. A unique identifier for the algorithm; and
+1. Some indication of how the output is used (e.g., for deriving the measurement
+   shares in Prio3 {{prio3}}).
+
+The following algorithm is used in the remainder of this document in order to
+format the customization string:
+
+~~~
+def format_custom(algo_class: Unsigned, algo: Unsigned, usage: Unsigned):
+    return I2OSP(VERSION, 1) + \
+           I2OSP(algo_class, 1) + \
+           I2OSP(algo, 4) + \
+           I2OSP(usage, 2)
+~~~
+
+It is also sometimes necessary to bind the output to some ephemeral value that
+muliple parties need to agree on. We call this input the "binder string".
 
 # Prio3 {#prio3}
 
@@ -1388,9 +1419,9 @@ For some FLPs, the encoded input also includes redundant field elements that are
 useful for checking the proof, but which are not needed after the proof has been
 checked. An example is the "integer sum" data type from {{CGB17}} in which an
 integer in range `[0, 2^k)` is encoded as a vector of `k` field elements (this
-type is also defined in {{prio3aes128sum}}). After consuming this vector,
-all that is needed is the integer it represents. Thus the FLP defines an
-algorithm for truncating the input to the length of the aggregated output:
+type is also defined in {{prio3sum}}). After consuming this vector, all that is
+needed is the integer it represents. Thus the FLP defines an algorithm for
+truncating the input to the length of the aggregated output:
 
 * `Flp.truncate(input: Vec[Field]) -> Vec[Field]` maps an encoded input to an
   aggregatable output. The length of the input MUST be `INPUT_LEN` and the length
@@ -1430,15 +1461,15 @@ methods refer to constants enumerated in {{prio3-const}}.
 | `AggResult`       | `Flp.AggResult`   |
 {: #prio3-param title="VDAF parameters for Prio3."}
 
-| Variable                       | Value |
-|:-------------------------------|:------|
-| `DST_MEASUREMENT_SHARE: Bytes` | 0x01  |
-| `DST_PROOF_SHARE: Bytes`       | 0x02  |
-| `DST_JOINT_RANDOMNESS: Bytes`  | 0x03  |
-| `DST_PROVE_RANDOMNESS: Bytes`  | 0x04  |
-| `DST_QUERY_RANDOMNESS: Bytes`  | 0x05  |
-| `DST_JOINT_RAND_SEED: Bytes`   | 0x06  |
-| `DST_JOINT_RAND_PART: Bytes`   | 0x07  |
+| Variable                          | Value |
+|:----------------------------------|:------|
+| `DST_MEASUREMENT_SHARE: Unsigned` | 1     |
+| `DST_PROOF_SHARE: Unsigned`       | 2     |
+| `DST_JOINT_RANDOMNESS: Unsigned`  | 3     |
+| `DST_PROVE_RANDOMNESS: Unsigned`  | 4     |
+| `DST_QUERY_RANDOMNESS: Unsigned`  | 5     |
+| `DST_JOINT_RAND_SEED: Unsigned`   | 6     |
+| `DST_JOINT_RAND_PART: Unsigned`   | 7     |
 {: #prio3-const title="Constants used by Prio3."}
 
 ### Sharding
@@ -1468,7 +1499,6 @@ The definitions of constants and a few auxiliary functions are defined in
 
 ~~~
 def measurement_to_input_shares(Prio3, measurement, nonce):
-    dst = VERSION + I2OSP(Prio3.ID, 4)
     inp = Prio3.Flp.encode(measurement)
 
     # Generate measurement shares.
@@ -1482,21 +1512,24 @@ def measurement_to_input_shares(Prio3, measurement, nonce):
         helper_meas_share = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_share,
-            dst + DST_MEASUREMENT_SHARE + byte(j+1),
+            Prio3.custom(DST_MEASUREMENT_SHARE),
+            byte(j+1),
             Prio3.Flp.INPUT_LEN
         )
         leader_meas_share = vec_sub(leader_meas_share,
                                     helper_meas_share)
         encoded = Prio3.Flp.Field.encode_vec(helper_meas_share)
         k_joint_rand_part = Prio3.Prg.derive_seed(k_blind,
-            dst + DST_JOINT_RAND_PART + byte(j+1) + nonce + encoded)
+            Prio3.custom(DST_JOINT_RAND_PART),
+            byte(j+1) + nonce + encoded)
         k_helper_meas_shares.append(k_share)
         k_helper_blinds.append(k_blind)
         k_joint_rand_parts.append(k_joint_rand_part)
     k_leader_blind = gen_rand(Prio3.Prg.SEED_SIZE)
     encoded = Prio3.Flp.Field.encode_vec(leader_meas_share)
     k_leader_joint_rand_part = Prio3.Prg.derive_seed(k_leader_blind,
-        dst + DST_JOINT_RAND_PART + byte(0) + nonce + encoded)
+        Prio3.custom(DST_JOINT_RAND_PART),
+        byte(0) + nonce + encoded)
     k_joint_rand_parts.insert(0, k_leader_joint_rand_part)
 
     # Compute joint randomness seed.
@@ -1506,14 +1539,16 @@ def measurement_to_input_shares(Prio3, measurement, nonce):
     prove_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         gen_rand(Prio3.Prg.SEED_SIZE),
-        dst + DST_PROVE_RANDOMNESS,
-        Prio3.Flp.PROVE_RAND_LEN
+        Prio3.custom(DST_PROVE_RANDOMNESS),
+        b'',
+        Prio3.Flp.PROVE_RAND_LEN,
     )
     joint_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         k_joint_rand,
-        dst + DST_JOINT_RANDOMNESS,
-        Prio3.Flp.JOINT_RAND_LEN
+        Prio3.custom(DST_JOINT_RANDOMNESS),
+        b'',
+        Prio3.Flp.JOINT_RAND_LEN,
     )
     proof = Prio3.Flp.prove(inp, prove_rand, joint_rand)
     leader_proof_share = proof
@@ -1524,8 +1559,9 @@ def measurement_to_input_shares(Prio3, measurement, nonce):
         helper_proof_share = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_share,
-            dst + DST_PROOF_SHARE + byte(j+1),
-            Prio3.Flp.PROOF_LEN
+            Prio3.custom(DST_PROOF_SHARE),
+            byte(j+1),
+            Prio3.Flp.PROOF_LEN,
         )
         leader_proof_share = vec_sub(leader_proof_share,
                                      helper_proof_share)
@@ -1577,42 +1613,40 @@ their verifier shares.
 The definitions of constants and a few auxiliary functions are defined in
 {{prio3-auxiliary}}.
 
-
 ~~~
 def prep_init(Prio3, verify_key, agg_id, _agg_param,
               nonce, public_share, input_share):
-    # Domain separation tag for PRG info string
-    dst = VERSION + I2OSP(Prio3.ID, 4)
-
     k_joint_rand_parts = Prio3.decode_public_share(public_share)
     (meas_share, proof_share, k_blind) = \
         Prio3.decode_leader_share(input_share) if agg_id == 0 else \
-        Prio3.decode_helper_share(dst, agg_id, input_share)
+        Prio3.decode_helper_share(agg_id, input_share)
     out_share = Prio3.Flp.truncate(meas_share)
 
     # Compute joint randomness.
     joint_rand = []
     k_corrected_joint_rand, k_joint_rand_part = None, None
     if Prio3.Flp.JOINT_RAND_LEN > 0:
+        encoded = Prio3.Flp.Field.encode_vec(meas_share)
         k_joint_rand_part = Prio3.Prg.derive_seed(k_blind,
-            dst + DST_JOINT_RAND_PART + \
-            byte(agg_id) + nonce + \
-            Prio3.Flp.Field.encode_vec(meas_share))
+            Prio3.custom(DST_JOINT_RAND_PART),
+            byte(agg_id) + nonce + encoded)
         k_joint_rand_parts[agg_id] = k_joint_rand_part
         k_corrected_joint_rand = Prio3.joint_rand(k_joint_rand_parts)
         joint_rand = Prio3.Prg.expand_into_vec(
             Prio3.Flp.Field,
             k_corrected_joint_rand,
-            dst + DST_JOINT_RANDOMNESS,
-            Prio3.Flp.JOINT_RAND_LEN
+            Prio3.custom(DST_JOINT_RANDOMNESS),
+            b'',
+            Prio3.Flp.JOINT_RAND_LEN,
         )
 
     # Query the measurement and proof share.
     query_rand = Prio3.Prg.expand_into_vec(
         Prio3.Flp.Field,
         verify_key,
-        dst + DST_QUERY_RANDOMNESS + nonce,
-        Prio3.Flp.QUERY_RAND_LEN
+        Prio3.custom(DST_QUERY_RANDOMNESS),
+        nonce,
+        Prio3.Flp.QUERY_RAND_LEN,
     )
     verifier_share = Prio3.Flp.query(meas_share,
                                      proof_share,
@@ -1637,7 +1671,6 @@ def prep_next(Prio3, prep, inbound):
     return out_share
 
 def prep_shares_to_prep(Prio3, _agg_param, prep_shares):
-    dst = VERSION + I2OSP(Prio3.ID, 4)
     verifier = Prio3.Flp.Field.zeros(Prio3.Flp.VERIFIER_LEN)
     k_joint_rand_parts = []
     for encoded in prep_shares:
@@ -1690,14 +1723,16 @@ def agg_shares_to_result(Prio3, _agg_param,
 
 ### Auxiliary Functions {#prio3-auxiliary}
 
-#### Joint Randomness Computation
-
 ~~~
 def joint_rand(Prio3, k_joint_rand_parts):
-    dst = VERSION + I2OSP(Prio3.ID, 4)
     return Prio3.Prg.derive_seed(
         zeros(Prio3.Prg.SEED_SIZE),
-        dst + DST_JOINT_RAND_SEED + concat(k_joint_rand_parts))
+        Prio3.custom(DST_JOINT_RAND_SEED),
+        concat(k_joint_rand_parts),
+    )
+
+def custom(Prio3, usage):
+    return format_custom(0, Prio3.ID, usage)
 ~~~
 
 #### Message Serialization
@@ -1742,19 +1777,21 @@ def encode_helper_share(Prio3,
         encoded += k_blind
     return encoded
 
-def decode_helper_share(Prio3, dst, agg_id, encoded):
-    info_meas_share = dst + DST_MEASUREMENT_SHARE + byte(agg_id)
-    info_proof_share = dst + DST_PROOF_SHARE + byte(agg_id)
+def decode_helper_share(Prio3, agg_id, encoded):
+    c_meas_share = Prio3.custom(DST_MEASUREMENT_SHARE)
+    c_proof_share = Prio3.custom(DST_PROOF_SHARE)
     l = Prio3.Prg.SEED_SIZE
     k_meas_share, encoded = encoded[:l], encoded[l:]
     meas_share = Prio3.Prg.expand_into_vec(Prio3.Flp.Field,
                                            k_meas_share,
-                                           info_meas_share,
+                                           c_meas_share,
+                                           byte(agg_id),
                                            Prio3.Flp.INPUT_LEN)
     k_proof_share, encoded = encoded[:l], encoded[l:]
     proof_share = Prio3.Prg.expand_into_vec(Prio3.Flp.Field,
                                             k_proof_share,
-                                            info_proof_share,
+                                            c_proof_share,
+                                            byte(agg_id),
                                             Prio3.Flp.PROOF_LEN)
     if Prio3.Flp.JOINT_RAND_LEN == 0:
         if len(encoded) != 0:
@@ -2193,12 +2230,12 @@ each can be found in {{test-vectors}}.
 > NOTE Reference implementations of each of these VDAFs can be found in
 > https://github.com/cfrg/draft-irtf-cfrg-vdaf/blob/main/poc/vdaf_prio3.sage.
 
-### Prio3Aes128Count
+### Prio3Count
 
 Our first instance of Prio3 is for a simple counter: Each measurement is either
 one or zero and the aggregate result is the sum of the measurements.
 
-This instance uses `PrgAes128` ({{prg-aes128}}) as its PRG. Its validity
+This instance uses PrgSha3 ({{prg-sha3}) as its PRG. Its validity
 circuit, denoted `Count`, uses `Field64` ({{field64}}) as its finite field. Its
 gadget, denoted `Mul`, is the degree-2, arity-2 gadget defined as
 
@@ -2229,17 +2266,16 @@ way. The parameters for this circuit are summarized below.
 | `Field`          | `Field64` ({{field64}})      |
 {: title="Parameters of validity circuit Count."}
 
-### Prio3Aes128Sum
+### Prio3Sum
 
 The next instance of Prio3 supports summing of integers in a pre-determined
 range. Each measurement is an integer in range `[0, 2^bits)`, where `bits` is an
 associated parameter.
 
-This instance of Prio3 uses `PrgAes128` ({{prg-aes128}}) as its PRG.
-Its validity circuit, denoted `Sum`, uses `Field128` ({{field128}}) as its
-finite field. The measurement is encoded as a length-`bits` vector of field
-elements, where the `l`th element of the vector represents the `l`th bit of the
-summand:
+This instance of Prio3 uses PrgSha3 ({{prg-sha3}}) as its PRG. Its validity
+circuit, denoted `Sum`, uses `Field128` ({{field128}}) as its finite field. The
+measurement is encoded as a length-`bits` vector of field elements, where the
+`l`th element of the vector represents the `l`th bit of the summand:
 
 ~~~
 def encode(Sum, measurement: Integer):
@@ -2294,17 +2330,17 @@ def Sum(inp: Vec[Field128], joint_rand: Vec[Field128]):
 | `Field`          | `Field128` ({{field128}})    |
 {: title="Parameters of validity circuit Sum."}
 
-### Prio3Aes128Histogram
+### Prio3Histogram
 
 This instance of Prio3 allows for estimating the distribution of the
 measurements by computing a simple histogram. Each measurement is an arbitrary
 integer and the aggregate result counts the number of measurements that fall in
 a set of fixed buckets.
 
-This instance of Prio3 uses `PrgAes128` ({{prg-aes128}}) as its PRG. Its
-validity circuit, denoted `Histogram`, uses `Field128` ({{field128}}) as its
-finite field. The measurement is encoded as a one-hot vector representing the
-bucket into which the measurement falls (let `bucket` denote a sequence of
+This instance of Prio3 uses PrgSha3 ({{prg-sha3}}) as its PRG. Its validity
+circuit, denoted `Histogram`, uses `Field128` ({{field128}}) as its finite
+field. The measurement is encoded as a one-hot vector representing the bucket
+into which the measurement falls (let `bucket` denote a sequence of
 monotonically increasing integers):
 
 ~~~
@@ -2323,7 +2359,7 @@ def decode(Histogram, output: Vec[Field128], _num_measurements):
     return [bucket_count.as_unsigned() for bucket_count in output]
 ~~~
 
-The validity circuit uses `Range2` (see {{prio3aes128sum}}) as its single gadget. It
+The validity circuit uses `Range2` (see {{prio3sum}}) as its single gadget. It
 checks for one-hotness in two steps, as follows:
 
 ~~~
@@ -2412,7 +2448,7 @@ is zero everywhere except for one element, which is equal to one.
 The remainder of this section is structured as follows. IDPFs are defined in
 {{idpf}}; a concrete instantiation is given {{idpf-poplar}}. The Poplar1 VDAF is
 defined in {{poplar1-construction}} in terms of a generic IDPF. Finally, a
-concrete instantiation of Poplar1 is specified in {{poplar1aes128}};
+concrete instantiation of Poplar1 is specified in {{poplar1-inst}};
 test vectors can be found in {{test-vectors}}.
 
 ## Incremental Distributed Point Functions (IDPFs) {#idpf}
@@ -2436,9 +2472,9 @@ length-3 prefix of 25 (11001), but 7 (111) is not.
 Each of the programmed points `beta` is a vector of elements of some finite
 field. We distinguish two types of fields: One for inner nodes (denoted
 `Idpf.FieldInner`), and one for leaf nodes (`Idpf.FieldLeaf`). (Our
-instantiation of Poplar1 ({{poplar1aes128}}) will use a much larger
-field for leaf nodes than for inner nodes. This is to ensure the IDPF is
-"extractable" as defined in {{BBCGGI21}}, Definition 1.)
+instantiation of Poplar1 ({{poplar1-inst}}) will use a much larger field for
+leaf nodes than for inner nodes. This is to ensure the IDPF is "extractable" as
+defined in {{BBCGGI21}}, Definition 1.)
 
 A concrete IDPF defines the types and constants enumerated in {{idpf-param}}. In
 the remainder we write `Idpf.Vec` as shorthand for the type
@@ -2540,12 +2576,10 @@ and sends additive shares of `a`, `b`, `c`, `A` and `B` to the Aggregators.
 Putting everything together, the input-distribution algorithm is defined as
 follows. Function `encode_input_shares` is defined in {{poplar1-helper-functions}}.
 
-
 ~~~
 def measurement_to_input_shares(Poplar1, measurement, _nonce):
-    dst = VERSION + I2OSP(Poplar1.ID, 4)
-    prg = Poplar1.Idpf.Prg(
-        gen_rand(Poplar1.Idpf.Prg.SEED_SIZE), dst + byte(255))
+    prg = Poplar1.Idpf.Prg(gen_rand(Poplar1.Idpf.Prg.SEED_SIZE),
+                           Poplar1.custom(DST_SHARD_RAND), b'')
 
     # Construct the IDPF values for each level of the IDPF tree.
     # Each "data" value is 1; in addition, the Client generates
@@ -2572,8 +2606,10 @@ def measurement_to_input_shares(Poplar1, measurement, _nonce):
         gen_rand(Poplar1.Idpf.Prg.SEED_SIZE),
     ]
     corr_prg = [
-        Poplar1.Idpf.Prg(corr_seed[0], dst + byte(0)),
-        Poplar1.Idpf.Prg(corr_seed[1], dst + byte(1)),
+        Poplar1.Idpf.Prg(corr_seed[0],
+                         Poplar1.custom(DST_CORR_SHARE), byte(0)),
+        Poplar1.Idpf.Prg(corr_seed[1],
+                         Poplar1.custom(DST_CORR_SHARE), byte(1)),
     ]
 
     # For each level of the IDPF tree, shares of the `(A, B)`
@@ -2613,13 +2649,12 @@ for each. The Aggregators use these and the correlation shares provided by the
 Client to verify that the sequence of `data_share` values are additive shares of
 a one-hot vector.
 
-The algorithms below make use of auxiliary functions `verify_context()` and
+The algorithms below make use of auxiliary functions `verify_binder()` and
 `decode_input_share()` defined in {{poplar1-helper-functions}}.
 
 ~~~
 def prep_init(Poplar1, verify_key, agg_id, agg_param,
               nonce, public_share, input_share):
-    dst = VERSION + I2OSP(Poplar1.ID, 4)
     (level, prefixes) = agg_param
     (key, corr_seed, corr_inner, corr_leaf) = \
         Poplar1.decode_input_share(input_share)
@@ -2636,7 +2671,9 @@ def prep_init(Poplar1, verify_key, agg_id, agg_param,
     # the IDPF will be evaluated incrementally beginning with
     # `level == 0`. Implementations can save computation by
     # storing the intermediate PRG state between evaluations.
-    corr_prg = Poplar1.Idpf.Prg(corr_seed, dst + byte(agg_id))
+    corr_prg = Poplar1.Idpf.Prg(corr_seed,
+                                Poplar1.custom(DST_CORR_SHARE),
+                                byte(agg_id))
     for current_level in range(level+1):
         Field = Poplar1.Idpf.current_field(current_level)
         (a_share, b_share, c_share) = corr_prg.next_vec(Field, 3)
@@ -2647,7 +2684,8 @@ def prep_init(Poplar1, verify_key, agg_id, agg_param,
     # called the "masked input values" [BBCGGI21, Appendix C.4].
     Field = Poplar1.Idpf.current_field(level)
     verify_rand_prg = Poplar1.Idpf.Prg(verify_key,
-        dst + Poplar1.verify_context(nonce, level, prefixes))
+        Poplar1.custom(DST_VERIFY_RAND),
+        Poplar1.verify_binder(nonce, level, prefixes))
     verify_rand = verify_rand_prg.next_vec(Field, len(prefixes))
     sketch_share = [a_share, b_share, c_share]
     out_share = []
@@ -2756,6 +2794,23 @@ def agg_shares_to_result(Poplar1, agg_param,
 ### Auxiliary Functions {#poplar1-helper-functions}
 
 ~~~
+def custom(Poplar1, usage):
+    return format_custom(0, Poplar1.ID, usage)
+
+def verify_binder(Poplar1, nonce, level, prefixes):
+    if len(nonce) > 255:
+        raise ERR_INPUT # nonce too long
+    binder = Bytes()
+    binder += byte(254)
+    binder += byte(len(nonce))
+    binder += nonce
+    binder += Poplar1.encode_agg_param(level, prefixes)
+    return binder
+~~~
+
+#### Message Serialization
+
+~~~
 def encode_input_shares(Poplar1, keys,
                         corr_seed, corr_inner, corr_leaf):
     input_shares = []
@@ -2822,20 +2877,17 @@ def decode_agg_param(Poplar1, encoded):
     if len(encoded) != 0:
         raise ERR_INPUT
     return (level, prefixes)
-
-def verify_context(Poplar1, nonce, level, prefixes):
-    if len(nonce) > 255:
-        raise ERR_INPUT # nonce too long
-    context = Bytes()
-    context += byte(254)
-    context += byte(len(nonce))
-    context += nonce
-    context += Poplar1.encode_agg_param(level, prefixes)
-    return context
 ~~~
 {: #poplar1-helpers title="Helper functions for Poplar1."}
 
 ## The IDPF scheme of {{BBCGGI21}} {#idpf-poplar}
+
+> TODO(issue#32) Consider replacing the generic `Prg` object here with some
+> fixed-key mode for AES (something along the lines of ia.cr/2019/074). This
+> would allow us to take advantage of hardware acceleration, which would
+> significantly improve performance. We use SHA-3 primarily to instantiate
+> random oracles, but the random oracle model may not be required for IDPF. More
+> investigation is needed.
 
 In this section we specify a concrete IDPF, called IdpfPoplar, suitable for
 instantiating Poplar1. The scheme gets its name from the name of the protocol of
@@ -3010,8 +3062,7 @@ def eval_next(IdpfPoplar, prev_seed, prev_ctrl,
 
 ~~~
 def extend(IdpfPoplar, seed):
-    dst = VERSION + b' idpf poplar extend'
-    prg = IdpfPoplar.Prg(seed, dst)
+    prg = IdpfPoplar.Prg(seed, format_custom(1, 0, 0), b'')
     s = [
         prg.next(IdpfPoplar.Prg.SEED_SIZE),
         prg.next(IdpfPoplar.Prg.SEED_SIZE),
@@ -3021,8 +3072,7 @@ def extend(IdpfPoplar, seed):
     return (s, t)
 
 def convert(IdpfPoplar, level, seed):
-    dst = VERSION + b' idpf poplar convert'
-    prg = IdpfPoplar.Prg(seed, dst)
+    prg = IdpfPoplar.Prg(seed, format_custom(1, 0, 1), b'')
     next_seed = prg.next(IdpfPoplar.Prg.SEED_SIZE)
     Field = IdpfPoplar.current_field(level)
     w = prg.next_vec(Field, IdpfPoplar.VALUE_LEN)
@@ -3066,12 +3116,11 @@ def decode_public_share(IdpfPoplar, encoded):
 ~~~
 {: #idpf-poplar-helpers title="Helper functions for IdpfPoplar."}
 
-## Poplar1Aes128
+## Instantiation {#poplar1-inst}
 
-We refer to Poplar1 instantiated with IdpfPoplar (`VALUE_LEN == 2`)
-and PrgAes128 ({{prg-aes128}}) as Poplar1Aes128. This VDAF is suitable
-for any positive value of `BITS`. Test vectors can be found in
-{{test-vectors}}.
+By default, Poplar1 is instantiated with IdpfPoplar (`VALUE_LEN == 2`) and
+PrgSha3 ({{prg-sha3}}). This VDAF is suitable for any positive value of `BITS`.
+Test vectors can be found in {{test-vectors}}.
 
 # Security Considerations {#security}
 
@@ -3146,12 +3195,12 @@ that `0xFFFF0000` through `0xFFFFFFFF` are reserved for private use.
 
 | Value                        | Scheme               | Type | Reference                |
 |:-----------------------------|:---------------------|:-----|:-------------------------|
-| `0x00000000`                 | Prio3Aes128Count     | VDAF | {{prio3aes128count}}     |
-| `0x00000001`                 | Prio3Aes128Sum       | VDAF | {{prio3aes128sum}}       |
-| `0x00000002`                 | Prio3Aes128Histogram | VDAF | {{prio3aes128histogram}} |
-| `0x00000003` to `0x00000FFF` | reserved for Prio3   | VDAF | n/a                      |
-| `0x00001000`                 | Poplar1Aes128        | VDAF | {{poplar1aes128}}        |
-| `0xFFFF0000` to `0xFFFFFFFF` | reserved             | n/a  | n/a                      |
+| `0x00000000`                 | Prio3Count         | VDAF | {{prio3count}}     |
+| `0x00000001`                 | Prio3Sum           | VDAF | {{prio3sum}}       |
+| `0x00000002`                 | Prio3Histogram     | VDAF | {{prio3histogram}} |
+| `0x00000003` to `0x00000FFF` | reserved for Prio3 | VDAF | n/a                |
+| `0x00001000`                 | Poplar1            | VDAF | {{poplar1-inst}}   |
+| `0xFFFF0000` to `0xFFFFFFFF` | reserved           | n/a  | n/a                |
 {: #codepoints title="Unique identifiers for (V)DAFs."}
 
 > TODO Add IANA considerations for the codepoints summarized in {{codepoints}}.
@@ -3186,7 +3235,7 @@ Byte strings are encoded in hexadecimal To make the tests deterministic,
 `gen_rand()` was replaced with a function that returns the requested number of
 `0x01` octets.
 
-## Prio3Aes128Count {#testvec-prio3aes128count}
+## Prio3Aes128Count {#testvec-prio3count}
 {:numbered="false"}
 
 ~~~
@@ -3217,7 +3266,7 @@ agg_share_1: >-
 agg_result: 1
 ~~~
 
-## Prio3Aes128Sum {#testvec-prio3aes128sum}
+## Prio3Aes128Sum {#testvec-prio3sum}
 {:numbered="false"}
 
 ~~~
@@ -3271,7 +3320,7 @@ agg_share_1: >-
 agg_result: 100
 ~~~
 
-## Prio3Aes128Histogram {#testvec-prio3aes128histogram}
+## Prio3Aes128Histogram {#testvec-prio3histogram}
 {:numbered="false"}
 
 ~~~
@@ -3324,7 +3373,7 @@ agg_share_1: >-
 agg_result: [0, 0, 1, 0]
 ~~~
 
-## Poplar1Aes128 {#testvec-poplar1aes128}
+## Poplar1Aes128 {#testvec-poplar1}
 {:numbered="false"}
 
 ### Sharding

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -11,9 +11,7 @@ import struct
 TEST_VECTOR = False
 
 # Document version, reved with each draft that contains breaking changes.
-DRAFT = '03'
-VERSION = bytes(bytearray('vdaf-{}'.format(DRAFT), 'ascii'))
-
+VERSION = 3
 
 # Primitive types
 Bool = bool
@@ -113,6 +111,13 @@ def OS2IP(octets, skip_assert=False):
 # Return the concatenated byte strings.
 def concat(parts: Vec[Bytes]) -> Bytes:
     return reduce(lambda x, y: x + y, parts)
+
+# Format PRG context for use with a (V)DAF.
+def format_custom(algo_class: Unsigned, algo: Unsigned, usage: Unsigned):
+    return I2OSP(VERSION, 1) + \
+           I2OSP(algo_class, 1) + \
+           I2OSP(algo, 4) + \
+           I2OSP(usage, 2)
 
 def print_wrapped_line(line, tab):
     width=72

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -2,8 +2,8 @@
 
 from copy import deepcopy
 from sagelib.common import ERR_DECODE, ERR_INPUT, I2OSP, OS2IP, VERSION, \
-                           Bytes, Error, Unsigned, Vec, byte, gen_rand, \
-                           vec_add, vec_neg, vec_sub, xor
+                           Bytes, Error, Unsigned, Vec, byte, format_custom, \
+                           gen_rand, vec_add, vec_neg, vec_sub, xor
 from sagelib.field import Field2
 from sagelib.idpf import Idpf, test_idpf, test_idpf_exhaustive
 import sagelib.field as field
@@ -152,8 +152,7 @@ class IdpfPoplar(Idpf):
 
     @classmethod
     def extend(IdpfPoplar, seed):
-        dst = VERSION + b' idpf poplar extend'
-        prg = IdpfPoplar.Prg(seed, dst)
+        prg = IdpfPoplar.Prg(seed, format_custom(1, 0, 0), b'')
         s = [
             prg.next(IdpfPoplar.Prg.SEED_SIZE),
             prg.next(IdpfPoplar.Prg.SEED_SIZE),
@@ -164,8 +163,7 @@ class IdpfPoplar(Idpf):
 
     @classmethod
     def convert(IdpfPoplar, level, seed):
-        dst = VERSION + b' idpf poplar convert'
-        prg = IdpfPoplar.Prg(seed, dst)
+        prg = IdpfPoplar.Prg(seed, format_custom(1, 0, 1), b'')
         next_seed = prg.next(IdpfPoplar.Prg.SEED_SIZE)
         Field = IdpfPoplar.current_field(level)
         w = prg.next_vec(Field, IdpfPoplar.VALUE_LEN)
@@ -235,7 +233,7 @@ class IdpfPoplar(Idpf):
 
 if __name__ == '__main__':
     cls = IdpfPoplar \
-                .with_prg(prg.PrgAes128) \
+                .with_prg(prg.PrgSha3) \
                 .with_value_len(2)
     test_idpf(cls.with_bits(16), 0b1111000011110000, 15, [0b1111000011110000])
     test_idpf(cls.with_bits(16), 0b1111000011110000, 14, [0b111100001111000])

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 from Cryptodome.Cipher import AES
-from Cryptodome.Hash import CMAC
+from Cryptodome.Hash import CMAC, cSHAKE128
 from Cryptodome.Util import Counter
 from Cryptodome.Util.number import bytes_to_long
-from sagelib.common import DRAFT, OS2IP, TEST_VECTOR, Bytes, Error, Unsigned, \
-                           zeros, gen_rand, next_power_of_2, print_wrapped_line
-
+from sagelib.common import I2OSP, OS2IP, TEST_VECTOR, Bytes, Error, \
+                           Unsigned, format_custom, zeros, gen_rand, \
+                           next_power_of_2, print_wrapped_line
 
 # The base class for PRGs.
 class Prg:
@@ -15,7 +15,7 @@ class Prg:
     SEED_SIZE: Unsigned
 
     # Construct a new instnace of this PRG from the given seed and info string.
-    def __init__(self, seed: Bytes, info: Bytes) -> Prg:
+    def __init__(self, seed: Bytes[Prg.SEED_SIZE], custom: Bytes, binder: Bytes):
         raise Error('not implemented')
 
     # Output the next `length` bytes of the PRG stream.
@@ -24,8 +24,8 @@ class Prg:
 
     # Derive a new seed.
     @classmethod
-    def derive_seed(Prg, seed: Bytes, info: Bytes) -> bytes:
-        prg = Prg(seed, info)
+    def derive_seed(Prg, seed: Bytes[Prg.SEED_SIZE], custom: Bytes, binder: Bytes):
+        prg = Prg(seed, custom, binder)
         return prg.next(Prg.SEED_SIZE)
 
     # Output the next `length` pseudorandom elements of `Field`.
@@ -43,22 +43,26 @@ class Prg:
     @classmethod
     def expand_into_vec(Prg,
                         Field,
-                        seed: Bytes,
-                        info: Bytes,
+                        seed: Bytes[Prg.SEED_SIZE],
+                        custom: Bytes,
+                        binder: Bytes,
                         length: Unsigned):
-        prg = Prg(seed, info)
+        prg = Prg(seed, custom, binder)
         return prg.next_vec(Field, length)
 
+# WARNING `PrgAes128` has been deprecated in favor of `PrgSha3`.
 class PrgAes128(Prg):
     # Associated parameters
     SEED_SIZE = 16
 
-    def __init__(self, seed, info):
+    def __init__(self, seed, custom, binder):
         self.length_consumed = 0
 
         # Use CMAC as a pseuodorandom function to derive a key.
         hasher = CMAC.new(seed, ciphermod=AES)
-        self.key = hasher.update(info).digest()
+        hasher.update(custom)
+        hasher.update(binder)
+        self.key = hasher.digest()
 
     def next(self, length: Unsigned) -> Bytes:
         block = int(self.length_consumed / 16)
@@ -72,37 +76,54 @@ class PrgAes128(Prg):
         stream = cipher.encrypt(zeros(offset + length))
         return stream[-length:]
 
+# PRG based on SHA-3 (cSHAKE128).
+class PrgSha3(Prg):
+    # Associated parameters
+    SEED_SIZE = 16
+
+    def __init__(self, seed, custom, binder):
+        # `custom` is used as the customization string; `seed || binder` is
+        # used as the main input string.
+        self.shake = cSHAKE128.new(custom=custom)
+        self.shake.update(seed)
+        self.shake.update(binder)
+
+    def next(self, length: Unsigned) -> Bytes:
+        return self.shake.read(length)
+
 ##
 # TESTS
 #
 
 def test_prg(Prg, F, expanded_len):
-    info = b'info string'
+    custom = format_custom(7, 1337, 2)
+    binder = b'a string that binds some protocol artifact to the output'
     seed = gen_rand(Prg.SEED_SIZE)
 
     # Test next
-    expanded_data = Prg(seed, info).next(expanded_len)
+    expanded_data = Prg(seed, custom, binder).next(expanded_len)
     assert len(expanded_data) == expanded_len
 
-    want = Prg(seed, info).next(700)
+    want = Prg(seed, custom, binder).next(700)
     got = b''
-    prg = Prg(seed, info)
+    prg = Prg(seed, custom, binder)
     for i in range(0, 700, 7):
         got += prg.next(7)
     assert got == want
 
     # Test derive
-    derived_seed = Prg.derive_seed(seed, info)
+    derived_seed = Prg.derive_seed(seed, custom, binder)
     assert len(derived_seed) == Prg.SEED_SIZE
 
     # Test expand_into_vec
-    expanded_vec = Prg.expand_into_vec(F, seed, info, expanded_len)
+    expanded_vec = Prg.expand_into_vec(F, seed, custom, binder, expanded_len)
     assert len(expanded_vec) == expanded_len
 
 
 if __name__ == '__main__':
     import json
     from sagelib.field import Field128
+    from sagelib.field import Field96
 
     cls = PrgAes128
     test_prg(cls, Field128, 23)
@@ -110,11 +131,11 @@ if __name__ == '__main__':
     # These constants were found in a brute-force search, and they test that
     # the PRG performs rejection sampling correctly when raw AES-CTR output
     # exceeds the prime modulus.
-    from sagelib.field import Field96
     expanded_vec = PrgAes128.expand_into_vec(
         Field96,
-        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x5f",
-        b"",
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x5f',
+        b'', # custom
+        b'', # binder
         146
     )
     assert expanded_vec[-1] == Field96(39729620190871453347343769187)
@@ -149,3 +170,4 @@ if __name__ == '__main__':
             json.dump(test_vector, f, indent=4, sort_keys=True)
             f.write('\n')
 
+    test_prg(PrgSha3, Field128, 23)

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from functools import reduce
-from sagelib.common import DRAFT, ERR_VERIFY, Bytes, Error, Unsigned, Vec, \
+from sagelib.common import ERR_VERIFY, VERSION, Bytes, Error, Unsigned, Vec, \
                            gen_rand, print_wrapped_line
 from typing import Optional, Tuple, Union
 import sagelib.field as field
@@ -213,9 +213,9 @@ def run_vdaf(Vdaf,
     if print_test_vec:
         pretty_print_vdaf_test_vec(Vdaf, test_vec, type_param)
 
-        os.system('mkdir -p test_vec/{}'.format(DRAFT))
-        with open('test_vec/{}/{}_{}.json'.format(
-            DRAFT, Vdaf.__name__, test_vec_instance), 'w') as f:
+        os.system('mkdir -p test_vec/{:02}'.format(VERSION))
+        with open('test_vec/{:02}/{}_{}.json'.format(
+            VERSION, Vdaf.__name__, test_vec_instance), 'w') as f:
             json.dump(test_vec, f, indent=4, sort_keys=True)
             f.write('\n')
 


### PR DESCRIPTION
Based on #135 (merge that first).
Closes #106.

Replace `PrgAes128` with a new scheme, `PrgSha3`, that uses SHA-3 in the cSHAKE128 mode of operation. Existing analysis models this object as a random oracle, and SHA-3 is a safer way to instantiate it.

Whenever the PRG is used to map a seed and some context to a finite domain, e.g., derive a fresh seed or a vector of field elements, the analysis models this function as an independent random oracle. One consequence of this is that we need to take care to ensure domain separation for each distinct usage of PRG. In particular, we need to format the inputs to the random oracle so that they are decodable.

To make this easier, we split the current "info string" into two components: The "context string" and the "binder string". The context string encodes the document version, algorithm, and some usage information; all of which was previously packed into the prefix of the info string. The "binder string" is an optional ephemeral artifact that we want to bind ot the output, e.g., the measurement shares in Prio3.

We set cSHAKE128's "customization string" to the context string. The seed is set to the start of the "main input" of cSHAKE128; and the remainder is the binder string. This is useful because the binder string may have arbitrary length; because the seed is always fixed length, it can always be decoded from the main input.