### PR TITLE
Poplar1: Bind nonce to correlated randomness derivation

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2597,7 +2597,7 @@ Putting everything together, the input-distribution algorithm is defined as
 follows. Function `encode_input_shares` is defined in {{poplar1-auxiliary}}.
 
 ~~~
-def measurement_to_input_shares(Poplar1, measurement, _nonce):
+def measurement_to_input_shares(Poplar1, measurement, nonce):
     prg = Poplar1.Idpf.Prg(gen_rand(Poplar1.Idpf.Prg.SEED_SIZE),
                            Poplar1.custom(DST_SHARD_RAND), b'')
 
@@ -2631,14 +2631,14 @@ def measurement_to_input_shares(Poplar1, measurement, _nonce):
             Poplar1.Idpf.FieldInner,
             corr_seed[0],
             Poplar1.custom(DST_CORR_INNER),
-            byte(0),
+            byte(0) + nonce,
             3 * (Poplar1.Idpf.BITS-1),
         ),
         Poplar1.Idpf.Prg.expand_into_vec(
             Poplar1.Idpf.FieldInner,
             corr_seed[1],
             Poplar1.custom(DST_CORR_INNER),
-            byte(1),
+            byte(1) + nonce,
             3 * (Poplar1.Idpf.BITS-1),
         ),
     )
@@ -2647,14 +2647,14 @@ def measurement_to_input_shares(Poplar1, measurement, _nonce):
             Poplar1.Idpf.FieldLeaf,
             corr_seed[0],
             Poplar1.custom(DST_CORR_LEAF),
-            byte(0),
+            byte(0) + nonce,
             3,
         ),
         Poplar1.Idpf.Prg.expand_into_vec(
             Poplar1.Idpf.FieldLeaf,
             corr_seed[1],
             Poplar1.custom(DST_CORR_LEAF),
-            byte(1),
+            byte(1) + nonce,
             3,
         ),
     )
@@ -2730,13 +2730,13 @@ def prep_init(Poplar1, verify_key, agg_id, agg_param,
     if level < Poplar1.Idpf.BITS - 1:
         corr_prg = Poplar1.Idpf.Prg(corr_seed,
                                     Poplar1.custom(DST_CORR_INNER),
-                                    byte(agg_id))
+                                    byte(agg_id) + nonce)
         # Fast-forward the PRG state to the current level.
         corr_prg.next_vec(Field, 3 * level)
     else:
         corr_prg = Poplar1.Idpf.Prg(corr_seed,
                                     Poplar1.custom(DST_CORR_LEAF),
-                                    byte(agg_id))
+                                    byte(agg_id) + nonce)
     (a_share, b_share, c_share) = corr_prg.next_vec(Field, 3)
     (A_share, B_share) = corr_inner[2*level:2*(level+1)] \
         if level < Poplar1.Idpf.BITS - 1 else corr_leaf

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -39,7 +39,7 @@ class Poplar1(Vdaf):
     AggResult = Vec[Unsigned]
 
     @classmethod
-    def measurement_to_input_shares(Poplar1, measurement, _nonce):
+    def measurement_to_input_shares(Poplar1, measurement, nonce):
         prg = Poplar1.Idpf.Prg(gen_rand(Poplar1.Idpf.Prg.SEED_SIZE),
                                Poplar1.custom(DST_SHARD_RAND), b'')
 
@@ -73,14 +73,14 @@ class Poplar1(Vdaf):
                 Poplar1.Idpf.FieldInner,
                 corr_seed[0],
                 Poplar1.custom(DST_CORR_INNER),
-                byte(0),
+                byte(0) + nonce,
                 3 * (Poplar1.Idpf.BITS-1),
             ),
             Poplar1.Idpf.Prg.expand_into_vec(
                 Poplar1.Idpf.FieldInner,
                 corr_seed[1],
                 Poplar1.custom(DST_CORR_INNER),
-                byte(1),
+                byte(1) + nonce,
                 3 * (Poplar1.Idpf.BITS-1),
             ),
         )
@@ -89,14 +89,14 @@ class Poplar1(Vdaf):
                 Poplar1.Idpf.FieldLeaf,
                 corr_seed[0],
                 Poplar1.custom(DST_CORR_LEAF),
-                byte(0),
+                byte(0) + nonce,
                 3,
             ),
             Poplar1.Idpf.Prg.expand_into_vec(
                 Poplar1.Idpf.FieldLeaf,
                 corr_seed[1],
                 Poplar1.custom(DST_CORR_LEAF),
-                byte(1),
+                byte(1) + nonce,
                 3,
             ),
         )
@@ -150,13 +150,13 @@ class Poplar1(Vdaf):
         if level < Poplar1.Idpf.BITS - 1:
             corr_prg = Poplar1.Idpf.Prg(corr_seed,
                                         Poplar1.custom(DST_CORR_INNER),
-                                        byte(agg_id))
+                                        byte(agg_id) + nonce)
             # Fast-forward the PRG state to the current level.
             corr_prg.next_vec(Field, 3 * level)
         else:
             corr_prg = Poplar1.Idpf.Prg(corr_seed,
                                         Poplar1.custom(DST_CORR_LEAF),
-                                        byte(agg_id))
+                                        byte(agg_id) + nonce)
         (a_share, b_share, c_share) = corr_prg.next_vec(Field, 3)
         (A_share, B_share) = corr_inner[2*level:2*(level+1)] \
             if level < Poplar1.Idpf.BITS - 1 else corr_leaf


### PR DESCRIPTION
Append the nonce to the binder string for deriving the offsets for the sketch computation. That way if the Aggregators use a nonce to verify a report other than the one that was picked by the Client, verification will likely fail.

This change is about defense-in-depth. We don't yet have an analysis to suggest this is necessary for either privacy or robustness. However given the importance of this binding for Prio3 (specifically for the joint randomness), it seems like a sensible change.