### PR TITLE
IDPF: Change byte order of packed control bits

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3132,15 +3132,10 @@ def convert(IdpfPoplar, level, seed):
 
 def encode_public_share(IdpfPoplar, correction_words):
     encoded = Bytes()
-    l = floor((2*IdpfPoplar.BITS + 7) / 8)
-    encoded_ctrl = [int(0)] * l
-    for (level, (_, ctrl_cw, _)) \
-        in enumerate(correction_words):
-        encoded_ctrl[level // 4] |= (
-            ctrl_cw[0].as_unsigned() |
-            (ctrl_cw[1].as_unsigned() << 1)
-        ) << (level % 4 * 2)
-    encoded += Bytes(encoded_ctrl)
+    control_bits = list(itertools.chain.from_iterable(
+        cw[1] for cw in correction_words
+    ))
+    encoded += pack_bits(control_bits)
     for (level, (seed_cw, _, w_cw)) \
         in enumerate(correction_words):
         Field = IdpfPoplar.current_field(level)
@@ -3151,14 +3146,13 @@ def encode_public_share(IdpfPoplar, correction_words):
 def decode_public_share(IdpfPoplar, encoded):
     l = floor((2*IdpfPoplar.BITS + 7) / 8)
     encoded_ctrl, encoded = encoded[:l], encoded[l:]
+    control_bits = unpack_bits(encoded_ctrl, 2 * IdpfPoplar.BITS)
     correction_words = []
     for level in range(IdpfPoplar.BITS):
         Field = IdpfPoplar.current_field(level)
         ctrl_cw = (
-            Field2((encoded_ctrl[level // 4] >>
-                (level % 4 * 2)) & 1),
-            Field2((encoded_ctrl[level // 4] >>
-                (level % 4 * 2 + 1)) & 1),
+            control_bits[level * 2],
+            control_bits[level * 2 + 1],
         )
         l = IdpfPoplar.Prg.SEED_SIZE
         seed_cw, encoded = encoded[:l], encoded[l:]
@@ -3172,6 +3166,21 @@ def decode_public_share(IdpfPoplar, encoded):
     if leftover_bits != 0 or len(encoded) != 0:
         raise ERR_DECODE
     return correction_words
+
+def pack_bits(bits: Vec[Field2]) -> Bytes:
+    byte_len = (len(bits) + 7) // 8
+    packed = [int(0)] * byte_len
+    for i, bit in enumerate(bits):
+        packed[i // 8] |= bit.as_unsigned() << (i % 8)
+    return Bytes(packed)
+
+def unpack_bits(packed_bits: Bytes, length: Unsigned) -> Vec[Field2]:
+    bits = []
+    for i in range(length):
+        bits.append(Field2(
+            (packed_bits[i // 8] >> (i % 8)) & 1
+        ))
+    return bits
 ~~~
 {: #idpf-poplar-helpers title="Helper functions for IdpfPoplar."}
 

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3166,23 +3166,15 @@ def decode_public_share(IdpfPoplar, encoded):
     if leftover_bits != 0 or len(encoded) != 0:
         raise ERR_DECODE
     return correction_words
-
-def pack_bits(bits: Vec[Field2]) -> Bytes:
-    byte_len = (len(bits) + 7) // 8
-    packed = [int(0)] * byte_len
-    for i, bit in enumerate(bits):
-        packed[i // 8] |= bit.as_unsigned() << (i % 8)
-    return Bytes(packed)
-
-def unpack_bits(packed_bits: Bytes, length: Unsigned) -> Vec[Field2]:
-    bits = []
-    for i in range(length):
-        bits.append(Field2(
-            (packed_bits[i // 8] >> (i % 8)) & 1
-        ))
-    return bits
 ~~~
 {: #idpf-poplar-helpers title="Helper functions for IdpfPoplar."}
+
+Here, `pack_bits()` takes a list of bits, packs each group of eight bits into a
+byte, in LSB to MSB order, padding the most significant bits of the last byte
+with zeros as necessary, and returns the byte array. `unpack_bits()` performs
+the reverse operation: it takes in a byte array and a number of bits, and
+returns a list of bits, extracting eight bits from each byte in turn, in LSB to
+MSB order, and stopping after the requested number of bits.
 
 ## Instantiation {#poplar1-inst}
 

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3174,7 +3174,9 @@ byte, in LSB to MSB order, padding the most significant bits of the last byte
 with zeros as necessary, and returns the byte array. `unpack_bits()` performs
 the reverse operation: it takes in a byte array and a number of bits, and
 returns a list of bits, extracting eight bits from each byte in turn, in LSB to
-MSB order, and stopping after the requested number of bits.
+MSB order, and stopping after the requested number of bits. If the byte array
+has an incorrect length, or if unused bits in the last bytes are not zero, it
+throws an error.
 
 ## Instantiation {#poplar1-inst}
 

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3132,13 +3132,15 @@ def convert(IdpfPoplar, level, seed):
 
 def encode_public_share(IdpfPoplar, correction_words):
     encoded = Bytes()
-    packed_ctrl = 0
+    l = floor((2*IdpfPoplar.BITS + 7) / 8)
+    encoded_ctrl = [int(0)] * l
     for (level, (_, ctrl_cw, _)) \
         in enumerate(correction_words):
-        packed_ctrl |= ctrl_cw[0].as_unsigned() << (2*level)
-        packed_ctrl |= ctrl_cw[1].as_unsigned() << (2*level+1)
-    l = floor((2*IdpfPoplar.BITS + 7) / 8)
-    encoded += I2OSP(packed_ctrl, l)
+        encoded_ctrl[level // 4] |= (
+            ctrl_cw[0].as_unsigned() |
+            (ctrl_cw[1].as_unsigned() << 1)
+        ) << (level % 4 * 2)
+    encoded += Bytes(encoded_ctrl)
     for (level, (seed_cw, _, w_cw)) \
         in enumerate(correction_words):
         Field = IdpfPoplar.current_field(level)
@@ -3149,20 +3151,25 @@ def encode_public_share(IdpfPoplar, correction_words):
 def decode_public_share(IdpfPoplar, encoded):
     l = floor((2*IdpfPoplar.BITS + 7) / 8)
     encoded_ctrl, encoded = encoded[:l], encoded[l:]
-    packed_ctrl = OS2IP(encoded_ctrl)
     correction_words = []
     for level in range(IdpfPoplar.BITS):
         Field = IdpfPoplar.current_field(level)
-        ctrl_cw = (Field2(packed_ctrl & 1),
-                   Field2((packed_ctrl >> 1) & 1))
-        packed_ctrl >>= 2
+        ctrl_cw = (
+            Field2((encoded_ctrl[level // 4] >>
+                (level % 4 * 2)) & 1),
+            Field2((encoded_ctrl[level // 4] >>
+                (level % 4 * 2 + 1)) & 1),
+        )
         l = IdpfPoplar.Prg.SEED_SIZE
         seed_cw, encoded = encoded[:l], encoded[l:]
         l = Field.ENCODED_SIZE * IdpfPoplar.VALUE_LEN
         encoded_w_cw, encoded = encoded[:l], encoded[l:]
         w_cw = Field.decode_vec(encoded_w_cw)
         correction_words.append((seed_cw, ctrl_cw, w_cw))
-    if packed_ctrl != 0 or len(encoded) != 0:
+    leftover_bits = encoded_ctrl[-1] >> (
+        ((IdpfPoplar.BITS + 3) % 4 + 1) * 2
+    )
+    if leftover_bits != 0 or len(encoded) != 0:
         raise ERR_DECODE
     return correction_words
 ~~~

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -202,10 +202,7 @@ class IdpfPoplar(Idpf):
             encoded_w_cw, encoded = encoded[:l], encoded[l:]
             w_cw = Field.decode_vec(encoded_w_cw)
             correction_words.append((seed_cw, ctrl_cw, w_cw))
-        leftover_bits = encoded_ctrl[-1] >> (
-            ((IdpfPoplar.BITS + 3) % 4 + 1) * 2
-        )
-        if leftover_bits != 0 or len(encoded) != 0:
+        if len(encoded) != 0:
             raise ERR_DECODE
         return correction_words
 
@@ -247,6 +244,11 @@ def unpack_bits(packed_bits: Bytes, length: Unsigned) -> Vec[Field2]:
         bits.append(Field2(
             (packed_bits[i // 8] >> (i % 8)) & 1
         ))
+    leftover_bits = packed_bits[-1] >> (
+        (length + 7) % 8 + 1
+    )
+    if (length + 7) // 8 != len(packed_bits) or leftover_bits != 0:
+        raise ERR_DECODE
     return bits
 
 


### PR DESCRIPTION
This changes the byte order of the packed control bits in the IdpfPoplar public share. The order of bits within each byte is the same, but control bits for the first level will now be encoded in the first byte of the public share.

Closes #147.