### PR TITLE
Specify nonce sizes for Prio3 and Poplar1

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1559,6 +1559,7 @@ methods refer to constants enumerated in {{prio3-const}}.
 | Parameter         | Value             |
 |:------------------|:------------------|
 | `VERIFY_KEY_SIZE` | `Prg.SEED_SIZE`   |
+| `NONCE_SIZE`      | `16`              |
 | `ROUNDS`          | `1`               |
 | `SHARES`          | in `[2, 256)`     |
 | `Measurement`     | `Flp.Measurement` |
@@ -2662,6 +2663,7 @@ the remaining subsections. These methods make use of constants defined in
 | Parameter         | Value             |
 |:------------------|:------------------|
 | `VERIFY_KEY_SIZE` | `Idpf.Prg.SEED_SIZE` |
+| `NONCE_SIZE`      | `16` |
 | `ROUNDS`          | `2` |
 | `SHARES`          | `2` |
 | `Measurement`     | `Unsigned` |


### PR DESCRIPTION
Set `NONCE_SIZE` in the Prio3 and Poplar1 constructions, as required by the VDAF definition. The nonces are 16 bytes long, matching the existing Sage reference implementations.

Related to #127