### PR TITLE
Poplar1: Hoist sketch check to prep_shares_to_prep

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2897,14 +2897,10 @@ def prep_next(Poplar1, prep_state, opt_sketch):
                 Field.encode_vec(sketch_share))
 
     elif step == b'sketch round 2' and opt_sketch != None:
-        prev_sketch = Field.decode_vec(opt_sketch)
-        if len(prev_sketch) == 0:
-            prev_sketch = Field.zeros(1)
-        elif len(prev_sketch) != 1:
+        if len(opt_sketch) == 0:
+            return prep_mem # Output shares
+        else:
             raise ERR_INPUT # prep message malformed
-        if prev_sketch[0] != Field(0):
-            raise ERR_VERIFY
-        return prep_mem # Output shares
 
     raise ERR_INPUT # unexpected input
 
@@ -2915,12 +2911,17 @@ def prep_shares_to_prep(Poplar1, agg_param, prep_shares):
     Field = Poplar1.Idpf.current_field(level)
     sketch = vec_add(Field.decode_vec(prep_shares[0]),
                      Field.decode_vec(prep_shares[1]))
-    if sketch == Field.zeros(len(sketch)):
-        # In order to reduce communication overhead, let the
-        # empty string denote the zero vector of the required
-        # length.
-        return b''
-    return Field.encode_vec(sketch)
+    if len(sketch) == 3:
+        return Field.encode_vec(sketch)
+    elif len(sketch) == 1:
+        if sketch == Field.zeros(1):
+            # In order to reduce communication overhead, let the
+            # empty string denote a successful sketch verification.
+            return b''
+        else:
+            raise ERR_VERIFY # sketch verification failed
+    else:
+        return ERR_INPUT # unexpected input length
 ~~~
 {: #poplar1-prep-state title="Preparation state for Poplar1."}
 


### PR DESCRIPTION
This hoists the final sketch verification check from `prep_next()` to `prep_shares_to_prep()`. As a result, the round 2 prepare message will always be the empty string, if it doesn't raise an error. (Previously, it could have been the empty string or a 32-byte encoded field element)

Closes #169.