### PR TITLE
Use littlen-endian byte-order for fields

### DIFF
--- a/poc/field.sage
+++ b/poc/field.sage
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 from sage.all import GF
-from sagelib.common import ERR_DECODE, I2OSP, OS2IP, Bytes, Error, Unsigned, \
-                           Vec, byte
+from sagelib.common import ERR_DECODE, to_le_bytes, from_le_bytes, Bytes, \
+                           Error, Unsigned, Vec, byte
 
 
 # The base class for finite fields.
@@ -33,7 +33,7 @@ class Field:
     def encode_vec(Field, data: Vec[Field]) -> Bytes:
         encoded = Bytes()
         for x in data:
-            encoded += I2OSP(x.as_unsigned(), Field.ENCODED_SIZE)
+            encoded += to_le_bytes(x.as_unsigned(), Field.ENCODED_SIZE)
         return encoded
 
     @classmethod
@@ -45,7 +45,7 @@ class Field:
         vec = []
         for i in range(0, len(encoded), L):
             encoded_x = encoded[i:i+L]
-            x = OS2IP(encoded_x)
+            x = from_le_bytes(encoded_x)
             if x >= Field.MODULUS:
                 raise ERR_DECODE # Integer is larger than modulus
             vec.append(Field(x))

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -2,9 +2,9 @@
 
 from copy import deepcopy
 import itertools
-from sagelib.common import ERR_DECODE, ERR_INPUT, I2OSP, OS2IP, VERSION, \
-                           Bytes, Error, Unsigned, Vec, byte, format_custom, \
-                           gen_rand, vec_add, vec_neg, vec_sub, xor
+from sagelib.common import ERR_DECODE, ERR_INPUT, VERSION, Bytes, Error, \
+                           Unsigned, Vec, byte, format_custom, gen_rand, \
+                           vec_add, vec_neg, vec_sub, xor
 from sagelib.field import Field2
 from sagelib.idpf import Idpf, test_idpf, test_idpf_exhaustive
 import sagelib.field as field
@@ -158,7 +158,7 @@ class IdpfPoplar(Idpf):
             prg.next(IdpfPoplar.Prg.SEED_SIZE),
             prg.next(IdpfPoplar.Prg.SEED_SIZE),
         ]
-        b = OS2IP(prg.next(1))
+        b = prg.next(1)[0]
         t = [Field2(b & 1), Field2((b >> 1) & 1)]
         return (s, t)
 

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -4,9 +4,9 @@ from __future__ import annotations
 from copy import deepcopy
 from collections import namedtuple
 from typing import Tuple, Union
-from sagelib.common import ERR_INPUT, ERR_VERIFY, I2OSP, OS2IP, TEST_VECTOR, \
-                           Bytes, Error, Unsigned, Vec, byte, gen_rand, \
-                           vec_add, vec_sub
+from sagelib.common import ERR_INPUT, ERR_VERIFY, TEST_VECTOR, Bytes, Error, \
+                           Unsigned, Vec, byte, from_be_bytes, gen_rand, \
+                           to_be_bytes, vec_add, vec_sub
 from sagelib.vdaf import Vdaf, test_vdaf
 import sagelib.idpf as idpf
 import sagelib.idpf_poplar as idpf_poplar
@@ -175,7 +175,7 @@ class Poplar1(Vdaf):
         # called the "masked input values" [BBCGGI21, Appendix C.4].
         verify_rand_prg = Poplar1.Idpf.Prg(verify_key,
             Poplar1.custom(DST_VERIFY_RAND),
-            nonce + I2OSP(level, 2))
+            nonce + to_be_bytes(level, 2))
         verify_rand = verify_rand_prg.next_vec(Field, len(prefixes))
         sketch_share = [a_share, b_share, c_share]
         out_share = []
@@ -310,24 +310,24 @@ class Poplar1(Vdaf):
         if len(prefixes) > 2^32 - 1:
             raise ERR_INPUT # too many prefixes
         encoded = Bytes()
-        encoded += I2OSP(level, 2)
-        encoded += I2OSP(len(prefixes), 4)
+        encoded += to_be_bytes(level, 2)
+        encoded += to_be_bytes(len(prefixes), 4)
         packed = 0
         for (i, prefix) in enumerate(prefixes):
             packed |= prefix << ((level+1) * i)
         l = floor(((level+1) * len(prefixes) + 7) / 8)
-        encoded += I2OSP(packed, l)
+        encoded += to_be_bytes(packed, l)
         return encoded
 
     @classmethod
     def decode_agg_param(Poplar1, encoded):
         encoded_level, encoded = encoded[:2], encoded[2:]
-        level = OS2IP(encoded_level)
+        level = from_be_bytes(encoded_level)
         encoded_prefix_count, encoded = encoded[:4], encoded[4:]
-        prefix_count = OS2IP(encoded_prefix_count)
+        prefix_count = from_be_bytes(encoded_prefix_count)
         l = floor(((level+1) * prefix_count + 7) / 8)
         encoded_packed, encoded = encoded[:l], encoded[l:]
-        packed = OS2IP(encoded_packed)
+        packed = from_be_bytes(encoded_packed)
         prefixes = []
         m = 2^(level+1) - 1
         for i in range(prefix_count):
@@ -389,10 +389,10 @@ if __name__ == '__main__':
     test_vdaf(Poplar1.with_bits(128),
         (
             127,
-            [OS2IP(b'0123456789abcdef')],
+            [from_be_bytes(b'0123456789abcdef')],
         ),
         [
-            OS2IP(b'0123456789abcdef'),
+            from_be_bytes(b'0123456789abcdef'),
         ],
         [1],
     )
@@ -400,13 +400,13 @@ if __name__ == '__main__':
         (
             63,
             [
-                OS2IP(b'00000000'),
-                OS2IP(b'01234567'),
+                from_be_bytes(b'00000000'),
+                from_be_bytes(b'01234567'),
             ],
         ),
         [
-            OS2IP(b'0123456789abcdef0123456789abcdef'),
-            OS2IP(b'01234567890000000000000000000000'),
+            from_be_bytes(b'0123456789abcdef0123456789abcdef'),
+            from_be_bytes(b'01234567890000000000000000000000'),
         ],
         [0, 2],
     )

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -2,9 +2,9 @@
 
 from copy import deepcopy
 from typing import Tuple
-from sagelib.common import ERR_DECODE, ERR_INPUT, ERR_VERIFY, I2OSP, \
-                           TEST_VECTOR, Bytes, Unsigned, Vec, byte, concat, \
-                           gen_rand, vec_add, vec_sub, zeros
+from sagelib.common import ERR_DECODE, ERR_INPUT, ERR_VERIFY, TEST_VECTOR, \
+                           Bytes, Unsigned, Vec, byte, concat, gen_rand, \
+                           vec_add, vec_sub, zeros
 from sagelib.vdaf import Vdaf, test_vdaf
 import sagelib.flp as flp
 import sagelib.flp_generic as flp_generic


### PR DESCRIPTION
Closes #90 

Add methods to_le_bytes/from_le_bytes for encoding/decoding unsigned
integers as little-endian bytes and use these for field element
serialization. This change is meant to improve alignment of the spec
with implementations, which largely prefer little endian to big endian
for representing field elements.

For consistency, rename I2OSP/OS2IP to to_be_bytes/from_be_bytes.

While at it, check in David's script for generating the PRG rejection
test case. This is not strictly needed, since we could just reverse the
order of the bytes in the test seed, but it will be useful later on.