### PR TITLE
Change rejection sampling test to use Field64

### DIFF
--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -143,15 +143,16 @@ if __name__ == '__main__':
     import json
     from sagelib.field import Field128, Field64, Field96
 
-    # Parameters match output of: probe_for_rejection(PrgSha3, Field96)
+    # This test case was found through brute-force search using this tool:
+    # https://github.com/divergentdave/vdaf-rejection-sampling-search
     expanded_vec = PrgSha3.expand_into_vec(
-        Field96,
-        b'@\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        Field64,
+        b'\x23\x1c\x40\x0d\xcb\xaf\xce\x34\x5e\xfd\x3c\xa7\x79\x65\xee\x06',
         b'', # custom
         b'', # binder
-        328,
+        5,
     )
-    assert expanded_vec[-1] == Field96(55625305487129755078517911529)
+    assert expanded_vec[-1] == Field64(13681157193520586550)
 
     for cls in (PrgAes128, PrgSha3):
         test_prg(cls, Field128, 23)

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -122,23 +122,6 @@ def test_prg(Prg, F, expanded_len):
     assert len(expanded_vec) == expanded_len
 
 
-# Find seeds for `Prg` for which, when expanded into a vector of `Field`
-# elements, an output larger than the field modulus is generated. The output is
-# used to write tests for proper rejection sampling in `Prg` implementations.
-def probe_for_rejection(Prg, Field, start_seed_int=0):
-    custom = b''
-    binder = b''
-    mask = next_power_of_2(Field.MODULUS) - 1
-    for seed_int in range(start_seed_int, start_seed_int+1_000_000):
-        seed = to_le_bytes(seed_int, Prg.SEED_SIZE)
-        prg = Prg(seed, custom, binder)
-        for offset in range(1024):
-            value = from_le_bytes(prg.next(Field.ENCODED_SIZE))
-            value &= mask
-            if value >= Field.MODULUS:
-                print('Rejection! field = {} seed = {}, offset = {}, next_value = {}'
-                      .format(Field.__name__, seed, offset, prg.next_vec(Field, 1)))
-
 if __name__ == '__main__':
     import json
     from sagelib.field import Field128, Field64, Field96


### PR DESCRIPTION
This changes out the rejection sampling test to use Field64, which is actually in the document. There's less of a gap between the Field64 modulus and the largest 64-bit integer than in the Field96 case, so I wrote a small Rust program to do so, instead of using Python. (the search takes about ~30s on eight cores with this, it was too slow with Python) For what it's worth, finding similar test vectors for Field128 and Field255/GF(2^255-19) is infeasible to practically impossible.