### PR TITLE
poc: Replace "deepcopy" pattern for class factories

### DIFF
--- a/poc/flp_generic.sage
+++ b/poc/flp_generic.sage
@@ -1,6 +1,5 @@
 # A generic FLP based on {{BBCGGI19}}, Theorem 4.3.
 
-from copy import deepcopy
 from sagelib.common import ERR_ABORT, ERR_INPUT, ERR_VERIFY, Bool, Error, \
                            Unsigned, Vec, next_power_of_2
 from sagelib.field import poly_eval, poly_interp, poly_mul, poly_strip
@@ -193,20 +192,20 @@ def query_wrapped(Valid, proof):
 class FlpGeneric(Flp):
     # Instantiate thie generic FLP the given validity circuit.
     @classmethod
-    def with_valid(FlpGeneric, Valid):
-        new_cls = deepcopy(FlpGeneric)
-        new_cls.Valid = Valid
-        new_cls.Measurement = Valid.Measurement
-        new_cls.AggResult = Valid.AggResult
-        new_cls.Field = Valid.Field
-        new_cls.PROVE_RAND_LEN = Valid.prove_rand_len()
-        new_cls.QUERY_RAND_LEN = Valid.query_rand_len()
-        new_cls.JOINT_RAND_LEN = Valid.JOINT_RAND_LEN
-        new_cls.INPUT_LEN = Valid.INPUT_LEN
-        new_cls.OUTPUT_LEN = Valid.OUTPUT_LEN
-        new_cls.PROOF_LEN = Valid.proof_len()
-        new_cls.VERIFIER_LEN = Valid.verifier_len()
-        return new_cls
+    def with_valid(FlpGeneric, TheValid):
+        class NewFlpGeneric(FlpGeneric):
+            Valid = TheValid
+            Measurement = TheValid.Measurement
+            AggResult = TheValid.AggResult
+            Field = TheValid.Field
+            PROVE_RAND_LEN = TheValid.prove_rand_len()
+            QUERY_RAND_LEN = TheValid.query_rand_len()
+            JOINT_RAND_LEN = TheValid.JOINT_RAND_LEN
+            INPUT_LEN = TheValid.INPUT_LEN
+            OUTPUT_LEN = TheValid.OUTPUT_LEN
+            PROOF_LEN = TheValid.proof_len()
+            VERIFIER_LEN = TheValid.verifier_len()
+        return NewFlpGeneric
 
     @classmethod
     def prove(FlpGeneric, inp, prove_rand, joint_rand):
@@ -472,20 +471,19 @@ class Sum(Valid):
         return [decoded]
 
     @classmethod
-    def decode(Count, output, _num_measurements):
+    def decode(Sum, output, _num_measurements):
         return output[0].as_unsigned()
 
     # Instantiate an instace of the `Sum` circuit for inputs in range `[0,
     # 2^bits)`.
     @classmethod
-    def with_bits(cls, bits):
-        if 2^bits >= cls.Field.MODULUS:
+    def with_bits(Sum, bits):
+        if 2^bits >= Sum.Field.MODULUS:
             raise Error('bit size exceeds field modulus')
-
-        new_cls = deepcopy(cls)
-        new_cls.GADGET_CALLS = [bits]
-        new_cls.INPUT_LEN = bits
-        return new_cls
+        class SumWithBits(Sum):
+            GADGET_CALLS = [bits]
+            INPUT_LEN = bits
+        return SumWithBits
 
     @classmethod
     def test_vec_set_type_param(cls, test_vec):
@@ -547,13 +545,13 @@ class Histogram(Valid):
 
     # Instantiate an instace of the `Histogram` circuit with the given buckets.
     @classmethod
-    def with_buckets(cls, buckets):
-        new_cls = deepcopy(cls)
-        new_cls.buckets = buckets
-        new_cls.GADGET_CALLS = [len(buckets) + 1]
-        new_cls.INPUT_LEN = len(buckets) + 1
-        new_cls.OUTPUT_LEN = len(buckets) + 1
-        return new_cls
+    def with_buckets(Histogram, the_buckets):
+        class HistogramWithBuckets(Histogram):
+            buckets = the_buckets
+            GADGET_CALLS = [len(the_buckets) + 1]
+            INPUT_LEN = len(the_buckets) + 1
+            OUTPUT_LEN = len(the_buckets) + 1
+        return HistogramWithBuckets
 
     @classmethod
     def test_vec_set_type_param(cls, test_vec):

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -1,6 +1,5 @@
 # An IDPF based on the construction of [BBCGGI21, Section 6].
 
-from copy import deepcopy
 import itertools
 from sagelib.common import ERR_DECODE, ERR_INPUT, TEST_VECTOR, VERSION, Bytes, \
                            Error, Unsigned, Vec, byte, format_custom, gen_rand, \
@@ -207,27 +206,27 @@ class IdpfPoplar(Idpf):
         return correction_words
 
     @classmethod
-    def with_prg(IdpfPoplar, Prg):
-        new_cls = deepcopy(IdpfPoplar)
-        new_cls.Prg = Prg
-        new_cls.KEY_SIZE = Prg.SEED_SIZE
-        return new_cls
+    def with_prg(IdpfPoplar, ThePrg):
+        class IdpfPoplarWithPrg(IdpfPoplar):
+            Prg = ThePrg
+            KEY_SIZE = ThePrg.SEED_SIZE
+        return IdpfPoplarWithPrg
 
     @classmethod
     def with_bits(IdpfPoplar, bits: Unsigned):
         if bits == 0:
             raise ERR_INPUT # number of bits must be positive
-        new_cls = deepcopy(IdpfPoplar)
-        new_cls.BITS = bits
-        return new_cls
+        class IdpfPoplarWithBits(IdpfPoplar):
+            BITS = bits
+        return IdpfPoplarWithBits
 
     @classmethod
     def with_value_len(IdpfPoplar, value_len: Unsigned):
         if value_len == 0:
             raise ERR_INPUT # value length must be positive
-        new_cls = deepcopy(IdpfPoplar)
-        new_cls.VALUE_LEN = value_len
-        return new_cls
+        class IdpfPoplarWithValueLen(IdpfPoplar):
+            VALUE_LEN = value_len
+        return IdpfPoplarWithValueLen
 
 
 def pack_bits(bits: Vec[Field2]) -> Bytes:

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -1,7 +1,6 @@
 # The Poplar1 VDAF.
 
 from __future__ import annotations
-from copy import deepcopy
 from collections import namedtuple
 from typing import Tuple, Union
 from sagelib.common import ERR_INPUT, ERR_VERIFY, TEST_VECTOR, Bytes, Error, \
@@ -338,19 +337,15 @@ class Poplar1(Vdaf):
         return (level, prefixes)
 
     @classmethod
-    def with_idpf(cls, Idpf):
-        new_cls = deepcopy(cls)
-        new_cls.Idpf = Idpf
-        new_cls.VERIFY_KEY_SIZE = Idpf.Prg.SEED_SIZE
-        return new_cls
-
-    @classmethod
-    def with_bits(cls, bits):
-        return cls.with_idpf(
-            idpf_poplar.IdpfPoplar \
+    def with_bits(Poplar1, bits: Unsigned):
+        TheIdpf = idpf_poplar.IdpfPoplar \
                 .with_prg(prg.PrgSha3) \
                 .with_value_len(2) \
-                .with_bits(bits))
+                .with_bits(bits)
+        class Poplar1WithBits(Poplar1):
+            Idpf = TheIdpf
+            VERIFY_KEY_SIZE = TheIdpf.Prg.SEED_SIZE
+        return Poplar1WithBits
 
     @classmethod
     def test_vec_set_type_param(cls, test_vec):


### PR DESCRIPTION
Partially addresses #163.

Properly construct a subclass instead of attempting to deep copy the superclass. The old pattern did not have the intended effect, which results in some subtle bugs.