### PR TITLE
poc: Plumb coins to `measurement_to_input_shares()`

### DIFF
--- a/poc/common.sage
+++ b/poc/common.sage
@@ -99,10 +99,14 @@ def to_be_bytes(val, length):
 def from_be_bytes(encoded):
     return int.from_bytes(encoded, byteorder='big')
 
-
 # Return the concatenated byte strings.
 def concat(parts: Vec[Bytes]) -> Bytes:
     return reduce(lambda x, y: x + y, parts)
+
+# Split list `vec` in two and return the front and remainder as a tuple. The
+# length of the front is `length`.
+def front(length, vec):
+    return (vec[:length], vec[length:])
 
 # Format PRG context for use with a (V)DAF.
 def format_custom(algo_class: Unsigned,

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -1,9 +1,21 @@
 # An IDPF based on the construction of [BBCGGI21, Section 6].
 
 import itertools
-from sagelib.common import ERR_DECODE, ERR_INPUT, TEST_VECTOR, VERSION, Bytes, \
-                           Error, Unsigned, Vec, byte, format_custom, gen_rand, \
-                           vec_add, vec_neg, vec_sub, xor
+from sagelib.common import \
+    ERR_DECODE, \
+    ERR_INPUT, \
+    TEST_VECTOR, \
+    VERSION, \
+    Bytes, \
+    Error, \
+    Unsigned, \
+    Vec, \
+    byte, \
+    format_custom, \
+    vec_add, \
+    vec_neg, \
+    vec_sub, \
+    xor
 from sagelib.field import Field2
 from sagelib.idpf import Idpf, gen_test_vec, test_idpf, test_idpf_exhaustive
 import sagelib.field as field
@@ -19,19 +31,22 @@ class IdpfPoplar(Idpf):
 
     # Parameters required by `Vdaf`.
     SHARES = 2
+    RAND_SIZE = None # Set by `Prg`
     FieldInner = field.Field64
     FieldLeaf = field.Field255
 
     @classmethod
-    def gen(IdpfPoplar, alpha, beta_inner, beta_leaf):
+    def gen(IdpfPoplar, alpha, beta_inner, beta_leaf, rand):
         if alpha >= 2^IdpfPoplar.BITS:
             raise ERR_INPUT # alpha too long
         if len(beta_inner) != IdpfPoplar.BITS - 1:
             raise ERR_INPUT # beta_inner vector is the wrong size
+        if len(rand) != IdpfPoplar.RAND_SIZE:
+            raise ERR_INPUT # unexpected length for random coins
 
         init_seed = [
-            gen_rand(IdpfPoplar.Prg.SEED_SIZE),
-            gen_rand(IdpfPoplar.Prg.SEED_SIZE),
+            rand[:IdpfPoplar.Prg.SEED_SIZE],
+            rand[IdpfPoplar.Prg.SEED_SIZE:],
         ]
 
         seed = init_seed.copy()
@@ -210,6 +225,7 @@ class IdpfPoplar(Idpf):
         class IdpfPoplarWithPrg(IdpfPoplar):
             Prg = ThePrg
             KEY_SIZE = ThePrg.SEED_SIZE
+            RAND_SIZE = 2*ThePrg.SEED_SIZE
         return IdpfPoplarWithPrg
 
     @classmethod


### PR DESCRIPTION
Based on #184 (merge that first).
Partially addresses #173.

To improve test vector quality, we will need to be able to specify a particular sequence of random coins used by the Client to split its measurement.

Add a paramter to `Daf.measurmeent_to_input_shares()` and `Vdaf.measurmeent_to_input_shares()` for the random coins. In addition, have the object specify the size of the byte string it expects. Similarly for `Idpf`.

Accordingly, remove all calls to `gen_rand()` from `Prio3`, `Poplar1`, and `IdpfPoplar` and instead use the coins passed to the API.