### PR TITLE
poc: Don't use class name for test vector name

### DIFF
--- a/poc/idpf.sage
+++ b/poc/idpf.sage
@@ -156,7 +156,7 @@ def gen_test_vec(Idpf, alpha, test_vec_instance):
 
     os.system('mkdir -p test_vec/{:02}'.format(VERSION))
     with open('test_vec/{:02}/{}_{}.json'.format(
-        VERSION, Idpf.__name__, test_vec_instance), 'w') as f:
+        VERSION, Idpf.test_vec_name, test_vec_instance), 'w') as f:
         json.dump(test_vec, f, indent=4, sort_keys=True)
         f.write('\n')
 

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -35,6 +35,9 @@ class IdpfPoplar(Idpf):
     FieldInner = field.Field64
     FieldLeaf = field.Field255
 
+    # Operational parameters.
+    test_vec_name = 'IdpfPoplar'
+
     @classmethod
     def gen(IdpfPoplar, alpha, beta_inner, beta_leaf, rand):
         if alpha >= 2^IdpfPoplar.BITS:

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -56,6 +56,9 @@ class PrgAes128(Prg):
     # Associated parameters
     SEED_SIZE = 16
 
+    # Operational parameters.
+    test_vec_name = 'PrgAes128'
+
     def __init__(self, seed, custom, binder):
         self.length_consumed = 0
 
@@ -82,6 +85,9 @@ class PrgAes128(Prg):
 class PrgSha3(Prg):
     # Associated parameters
     SEED_SIZE = 16
+
+    # Operational parameters.
+    test_vec_name = 'PrgSha3'
 
     def __init__(self, seed, custom, binder):
         # `custom` is used as the customization string; `seed || binder` is
@@ -159,7 +165,7 @@ if __name__ == '__main__':
             test_vector['expanded_vec_field128'] = Field128.encode_vec(
                     cls.expand_into_vec(Field128, seed, custom, binder, length)).hex()
 
-            print('{}:'.format(cls.__name__))
+            print('{}:'.format(cls.test_vec_name))
             print('  seed: "{}"'.format(test_vector['seed']))
             print('  custom: "{}"'.format(test_vector['custom']))
             print('  binder: "{}"'.format(test_vector['binder']))

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -243,7 +243,7 @@ def run_vdaf(Vdaf,
 
         os.system('mkdir -p test_vec/{:02}'.format(VERSION))
         with open('test_vec/{:02}/{}_{}.json'.format(
-            VERSION, Vdaf.__name__, test_vec_instance), 'w') as f:
+            VERSION, Vdaf.test_vec_name, test_vec_instance), 'w') as f:
             json.dump(test_vec, f, indent=4, sort_keys=True)
             f.write('\n')
 
@@ -251,7 +251,7 @@ def run_vdaf(Vdaf,
 
 
 def pretty_print_vdaf_test_vec(Vdaf, test_vec, type_param):
-    print('---------- {} ---------------'.format(Vdaf.__name__))
+    print('---------- {} ---------------'.format(Vdaf.test_vec_name))
     if type_param != None:
         print('{}: {}'.format(type_param, test_vec[type_param]))
     print('verify_key: "{}"'.format(test_vec['verify_key']))
@@ -410,7 +410,7 @@ def test_vdaf(Vdaf,
                           test_vec_instance)
     if agg_result != expected_agg_result:
         print('vdaf test failed ({} on {}): unexpected result: got {}; want {}'.format(
-            Vdaf.__name__, measurements, agg_result, expected_agg_result))
+            Vdaf.test_vec_name, measurements, agg_result, expected_agg_result))
 
 
 if __name__ == '__main__':

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -50,6 +50,9 @@ class Poplar1(Vdaf):
                      Vec[Vec[Idpf.FieldLeaf]]]
     AggResult = Vec[Unsigned]
 
+    # Operational parameters.
+    test_vec_name = 'Poplar1'
+
     @classmethod
     def measurement_to_input_shares(Poplar1, measurement, nonce, rand):
         l = Poplar1.Idpf.Prg.SEED_SIZE
@@ -366,6 +369,7 @@ class Poplar1(Vdaf):
             Idpf = TheIdpf
             VERIFY_KEY_SIZE = TheIdpf.Prg.SEED_SIZE
             RAND_SIZE = 3*TheIdpf.Prg.SEED_SIZE + TheIdpf.RAND_SIZE
+            test_vec_name = 'Poplar1'
         return Poplar1WithBits
 
     @classmethod

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -430,6 +430,9 @@ class Prio3Count(Prio3):
     ID = 0x00000000
     VERIFY_KEY_SIZE = prg.PrgSha3.SEED_SIZE
 
+    # Operational parameters.
+    test_vec_name = 'Prio3Count'
+
 class Prio3Sum(Prio3):
     # Generic types required by `Prio3`
     Prg = prg.PrgSha3
@@ -437,6 +440,9 @@ class Prio3Sum(Prio3):
     # Associated parameters.
     VERIFY_KEY_SIZE = prg.PrgSha3.SEED_SIZE
     ID = 0x00000001
+
+    # Operational parameters.
+    test_vec_name = 'Prio3Sum'
 
     @classmethod
     def with_bits(Prio3Sum, bits: Unsigned):
@@ -452,6 +458,9 @@ class Prio3Histogram(Prio3):
     # Associated parameters.
     VERIFY_KEY_SIZE = prg.PrgSha3.SEED_SIZE
     ID = 0x00000002
+
+    # Operational parameters.
+    test_vec_name = 'Prio3Histogram'
 
     @classmethod
     def with_buckets(Prio3Histogram, buckets: Vec[Unsigned]):


### PR DESCRIPTION
Based on #187 (merge that first).
Partially addresses #173.

We currently use the class name to name the file containing teste vectors for it. We create subclasses to specialize a `Vdaf` (or `Prg`, `Idpf`, etc.) with a given parameter. It is helpful to have that subclass have a distinguished name, e.g., `Prio3SumWithShares`. However, this name is not particularly helpful as a name for the file.

To fix this, add a `test_vec_name` class parameter to each class for which we generate test vectors and use that as the filename instead of `__class__`.