### PR TITLE
Propagate changes to randomness handling to spec

### DIFF
--- a/poc/daf.sage
+++ b/poc/daf.sage
@@ -103,7 +103,7 @@ def run_daf(Daf,
                 Daf.prep(j, agg_param, public_share, input_shares[j]))
 
     # Each Aggregator aggregates its output shares into an aggregate
-    # share and it to the Collector.
+    # share and sends it to the Collector.
     agg_shares = []
     for j in range(Daf.SHARES):
         agg_share_j = Daf.out_shares_to_agg_share(agg_param,


### PR DESCRIPTION
Closes #173.

* Add a parameter to all randomized algorithms that consists of the random coins consumed by that algorithm. Namely:

  * `Daf.measurement_to_input_shares()`
  * `Vdaf.measurement_to_input_shares()`
  * `Idpf.gen()`

  Have the algorithm specify the required length of the random istring.

* Update `Prio3`, `Poplar1`, and `IdpfPoplar` accordingly.

* Update `run_daf()` and `run_vdaf()` accordingly.

* Revise description of fixed random coins used for generating test vectors.

While at it, pick up a couple small editorial things:

* Replace instances of "input-distribution algorithm" with "sharding algorithm" for consistency.

* poc: Fix typo in a comment in `run_daf()`.