### PR TITLE
Include binder in IDPF test vector

### DIFF
--- a/poc/idpf.sage
+++ b/poc/idpf.sage
@@ -155,6 +155,7 @@ def gen_test_vec(Idpf, alpha, test_vec_instance):
         'alpha': str(alpha),
         'beta_inner': printable_beta_inner,
         'beta_leaf': printable_beta_leaf,
+        'binder': binder.hex(),
         'public_share': public_share.hex(),
         'keys': printable_keys,
     }


### PR DESCRIPTION
This adds the binder input to the IDPF test vector, since it's now an input to the key generation function.