### PR TITLE
Convert common.sage to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ venv/
 sagelib
 *.sage.py
 *.bak
+*.pyc
+*.pyo
+__pycache__

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -15,7 +15,7 @@ sagelib/%.py: %.sage
 	@mv $<.py $@
 
 test: pyfiles
-	sage common.sage
+	sage -python common.py
 	sage field.sage
 	sage prg.sage
 	sage flp.sage

--- a/poc/README.md
+++ b/poc/README.md
@@ -17,7 +17,7 @@ sage --pip install pycryptodomex
 
 ## Generating test vectors
 
-To generate test vectors, set the value of `TEST_VECTOR` in `common.sage` to
+To generate test vectors, set the value of `TEST_VECTOR` in `common.py` to
 `True` and run `make test`.
 
 > TODO Make this an environment variable.

--- a/poc/common.py
+++ b/poc/common.py
@@ -5,7 +5,6 @@ from typing import List, TypeVar
 import os
 import struct
 
-
 # If set, then test vectors will be generated. A fixed source of randomness is
 # used for `gen_rand()`.
 TEST_VECTOR = False
@@ -37,7 +36,7 @@ ERR_VERIFY = Error('verification of the user\'s input failed')
 # Return the smallest power of 2 that is larger than or equal to n.
 def next_power_of_2(n):
     assert n > 0
-    return 2^((n-1).nbits())
+    return 2 ** ((n - 1).nbits())
 
 
 # Return the requested number of zero bytes.
@@ -62,8 +61,7 @@ def byte(number) -> bytes:
 
 # Return the bitwise XOR of the inputs.
 def xor(left, right):
-    # NOTE Sage overloads the `^` operator, hence calling `__xor__()` directly.
-    return bytes(map(lambda x: x[0].__xor__(x[1]), zip(left, right)))
+    return bytes(map(lambda x: x[0] ^ x[1], zip(left, right)))
 
 
 # Subtract the right operand from the left and return the result.
@@ -75,9 +73,11 @@ def vec_sub(left, right):
 def vec_add(left, right):
     return list(map(lambda x: x[0] + x[1], zip(left, right)))
 
+
 # Negate the input vector.
 def vec_neg(vec):
     return list(map(lambda x: -x, vec))
+
 
 # Convert unsigned integer `val` in range `[0, 2^(8*length))` to a little-endian
 # byte string.
@@ -87,9 +87,11 @@ def to_le_bytes(val, length):
         raise ValueError('bad to_le_bytes call: val=%d length=%d' % (val, length))
     return val.to_bytes(length, byteorder='little')
 
+
 # Parse an unsigned integer from a little-endian byte string.
 def from_le_bytes(encoded):
     return int.from_bytes(encoded, byteorder='little')
+
 
 # Convert unsigned integer `val` in range `[0, 2^(8*length))` to a big-endian
 # byte string.
@@ -99,18 +101,22 @@ def to_be_bytes(val, length):
         raise ValueError('bad to_be_bytes call: val=%d length=%d' % (val, length))
     return val.to_bytes(length, byteorder='big')
 
+
 # Parse an unsigned integer from a big-endian byte string.
 def from_be_bytes(encoded):
     return int.from_bytes(encoded, byteorder='big')
+
 
 # Return the concatenated byte strings.
 def concat(parts: Vec[Bytes]) -> Bytes:
     return reduce(lambda x, y: x + y, parts)
 
+
 # Split list `vec` in two and return the front and remainder as a tuple. The
 # length of the front is `length`.
 def front(length, vec):
     return (vec[:length], vec[length:])
+
 
 # Format PRG context for use with a (V)DAF.
 def format_custom(algo_class: Unsigned,
@@ -121,9 +127,10 @@ def format_custom(algo_class: Unsigned,
            to_be_bytes(algo, 4) + \
            to_be_bytes(usage, 2)
 
+
 def print_wrapped_line(line, tab):
-    width=72
+    width = 72
     chunk_len = width - tab
     for start in range(0, len(line), chunk_len):
-        end = min(start+chunk_len, len(line))
+        end = min(start + chunk_len, len(line))
         print(' ' * tab + line[start:end])

--- a/poc/daf.sage
+++ b/poc/daf.sage
@@ -1,7 +1,7 @@
 # Definition of DAFs.
 
 from __future__ import annotations
-from sagelib.common import Unsigned, Vec, gen_rand
+from common import Unsigned, Vec, gen_rand
 import sagelib.field as field
 from sagelib.prg import PrgSha3
 import json

--- a/poc/field.sage
+++ b/poc/field.sage
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 from sage.all import GF
-from sagelib.common import ERR_DECODE, to_le_bytes, from_le_bytes, Bytes, \
-                           Error, Unsigned, Vec, byte
+from common import ERR_DECODE, to_le_bytes, from_le_bytes, Bytes, \
+                   Error, Unsigned, Vec, byte
 
 
 # The base class for finite fields.

--- a/poc/flp.sage
+++ b/poc/flp.sage
@@ -1,7 +1,7 @@
 # Fully linear proof (FLP) systems.
 
 from copy import deepcopy
-from sagelib.common import ERR_ENCODE, ERR_INPUT, Bool, Error, Unsigned, Vec
+from common import ERR_ENCODE, ERR_INPUT, Bool, Error, Unsigned, Vec
 
 import sagelib.field as field
 

--- a/poc/flp_generic.sage
+++ b/poc/flp_generic.sage
@@ -1,7 +1,7 @@
 # A generic FLP based on {{BBCGGI19}}, Theorem 4.3.
 
-from sagelib.common import ERR_ABORT, ERR_INPUT, ERR_VERIFY, Bool, Error, \
-                           Unsigned, Vec, next_power_of_2
+from common import ERR_ABORT, ERR_INPUT, ERR_VERIFY, Bool, Error, \
+                   Unsigned, Vec, next_power_of_2
 from sagelib.field import poly_eval, poly_interp, poly_mul, poly_strip
 from sagelib.flp import Flp, run_flp
 import sagelib.field as field

--- a/poc/idpf.sage
+++ b/poc/idpf.sage
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Union
-from sagelib.common import \
+from common import \
     VERSION, \
     Bool, \
     Bytes, \

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -1,7 +1,7 @@
 # An IDPF based on the construction of [BBCGGI21, Section 6].
 
 import itertools
-from sagelib.common import \
+from common import \
     ERR_DECODE, \
     ERR_INPUT, \
     TEST_VECTOR, \

--- a/poc/prg.sage
+++ b/poc/prg.sage
@@ -5,10 +5,10 @@ from Cryptodome.Cipher import AES
 from Cryptodome.Hash import CMAC, cSHAKE128
 from Cryptodome.Util import Counter
 from Cryptodome.Util.number import bytes_to_long
-from sagelib.common import TEST_VECTOR, VERSION, Bytes, Error, Unsigned, \
-                           format_custom, zeros, from_le_bytes, gen_rand, \
-                           next_power_of_2, print_wrapped_line, to_be_bytes, \
-                           to_le_bytes, xor, concat
+from common import TEST_VECTOR, VERSION, Bytes, Error, Unsigned, \
+                   format_custom, zeros, from_le_bytes, gen_rand, \
+                   next_power_of_2, print_wrapped_line, to_be_bytes, \
+                   to_le_bytes, xor, concat
 
 # The base class for PRGs.
 class Prg:

--- a/poc/vdaf.sage
+++ b/poc/vdaf.sage
@@ -4,9 +4,9 @@ from __future__ import annotations
 from functools import reduce
 import json
 import os
-from sagelib.common import ERR_VERIFY, VERSION, Bytes, Error, Unsigned, Vec, \
-                           format_custom, gen_rand, to_le_bytes, \
-                           print_wrapped_line
+from common import ERR_VERIFY, VERSION, Bytes, Error, Unsigned, Vec, \
+                   format_custom, gen_rand, to_le_bytes, \
+                   print_wrapped_line
 import sagelib.field as field
 from sagelib.prg import PrgSha3
 from typing import Optional, Tuple, Union

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from collections import namedtuple
 from typing import Tuple, Union
-from sagelib.common import \
+from common import \
     ERR_INPUT, \
     ERR_VERIFY, \
     TEST_VECTOR, \

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -1,7 +1,7 @@
 # The prio3 VDAF.
 
 from typing import Tuple
-from sagelib.common import \
+from common import \
     ERR_DECODE, \
     ERR_INPUT, \
     ERR_VERIFY, \


### PR DESCRIPTION
This converts `common.sage` to Python, as a first incremental step towards #204. This required two `^` changes, and then adjustments to import statements in other files.