### PR TITLE
poc: Change superclass of Error to Exception

### DIFF
--- a/poc/common.py
+++ b/poc/common.py
@@ -20,7 +20,7 @@ Vec = List
 
 
 # Base class for errors.
-class Error(BaseException):
+class Error(Exception):
     def __init__(self, msg):
         self.msg = msg
 


### PR DESCRIPTION
This changes the superclass of `Error` to be `Exception` instead of `BaseException`. The [exception documentation](https://docs.python.org/3/library/exceptions.html) says that new exception types should typically do so. Inheriting directly from `BaseException` is reserved for special things like `GeneratorExit`, `KeyboardInterrupt`, `SystemExit`, etc.