### PR TITLE
Simplify print_wrapped_line()

### DIFF
--- a/poc/common.py
+++ b/poc/common.py
@@ -132,5 +132,4 @@ def print_wrapped_line(line, tab):
     width = 72
     chunk_len = width - tab
     for start in range(0, len(line), chunk_len):
-        end = min(start + chunk_len, len(line))
-        print(' ' * tab + line[start:end])
+        print(' ' * tab + line[start:start + chunk_len])


### PR DESCRIPTION
This simplifies `print_wrapped_line()`: we don't need to use `min()` because string slicing in Python automatically truncates.