### PR TITLE
Convert daf and vdaf modules to python

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -652,7 +652,7 @@ measurements into a sequence of input shares. The `measurement_to_input_shares`
 method is used for this purpose.
 
 * `Daf.measurement_to_input_shares(input: Measurement, rand:
-  Bytes[Daf.RAND_SIZE]) -> (Bytes, Vec[Bytes])` is the randomized sharding
+  Bytes[Daf.RAND_SIZE]) -> tuple[Bytes, Vec[Bytes]]` is the randomized sharding
   algorithm run by each Client. (The input `rand` consists of the random coins
   consumed by the algorithm.) It consumes the measurement and produces a "public
   share", distributed to each of the Aggregators, and a corresponding sequence
@@ -920,11 +920,11 @@ Sharding transforms a measurement into input shares as it does in DAFs
 produces a public share:
 
 * `Vdaf.measurement_to_input_shares(measurement: Measurement, nonce:
-  Bytes[Vdaf.NONCE_SIZE], rand: Bytes[Vdaf.RAND_SIZE]) -> (Bytes, Vec[Bytes])`
-  is the randomized sharding algorithm run by each Client. (Input `rand`
-  consists of the random coins consumed by the algorithm.) It consumes the
-  measurement and the nonce and produces a public share, distributed to each of
-  Aggregators, and the corresponding sequence of input shares, one for each
+  Bytes[Vdaf.NONCE_SIZE], rand: Bytes[Vdaf.RAND_SIZE]) -> tuple[Bytes,
+  Vec[Bytes]]` is the randomized sharding algorithm run by each Client. (Input
+  `rand` consists of the random coins consumed by the algorithm.) It consumes
+  the measurement and the nonce and produces a public share, distributed to each
+  of Aggregators, and the corresponding sequence of input shares, one for each
   Aggregator. Depending on the VDAF, the input shares may encode additional
   information used to verify the recovered output shares (e.g., the "proof
   shares" in Prio3 {{prio3}}). The length of the output vector MUST be `SHARES`.

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -22,7 +22,7 @@ test: pyfiles
 	sage flp_generic.sage
 	sage idpf.sage
 	sage idpf_poplar.sage
-	sage daf.sage
-	sage vdaf.sage
+	sage -python daf.py
+	sage -python vdaf.py
 	sage vdaf_prio3.sage
 	sage vdaf_poplar1.sage

--- a/poc/daf.py
+++ b/poc/daf.py
@@ -1,7 +1,8 @@
 """Definition of DAFs."""
 
 from __future__ import annotations
-from common import Unsigned, Vec, gen_rand
+from common import Bool, Bytes, Error, Unsigned, Vec, gen_rand
+from functools import reduce
 import sagelib.field as field
 from sagelib.prg import PrgSha3
 import json
@@ -34,8 +35,8 @@ class Daf:
     @classmethod
     def measurement_to_input_shares(Daf,
                                     measurement: Measurement,
-                                    rand: Bytes[Vdaf.RAND_SIZE],
-                                    ) -> (Bytes, Vec[Bytes]):
+                                    rand: Bytes["Daf.RAND_SIZE"],
+                                    ) -> tuple[Bytes, Vec[Bytes]]:
         """
         Shard a measurement into a "public share" and a sequence of input
         shares, one for each Aggregator. This method is run by the Client.
@@ -179,7 +180,7 @@ def test_daf(Daf,
              measurements,
              expected_agg_result):
     # Test that the algorithm identifier is in the correct range.
-    assert 0 <= Daf.ID and Daf.ID < 2^32
+    assert 0 <= Daf.ID and Daf.ID < 2 ** 32
 
     # Run the DAF on the set of measurements.
     agg_result = run_daf(Daf,

--- a/poc/daf.sage
+++ b/poc/daf.sage
@@ -88,14 +88,6 @@ class Daf:
         """
         raise Error('not implemented')
 
-    @classmethod
-    def test_vector_verify_params(Daf, verify_params: Vec[VerifyParam]):
-        """
-        Returns a printable version of the verification parameters. This is used
-        for test vector generation.
-        """
-        raise Error('not implemented')
-
 
 def run_daf(Daf,
             agg_param: Daf.AggParam,
@@ -180,10 +172,6 @@ class TestDaf(Daf):
         return [reduce(lambda x, y: [x[0] + y[0]],
             map(lambda encoded: cls.Field.decode_vec(encoded),
                 agg_shares))[0].as_unsigned()]
-
-    @classmethod
-    def test_vector_verify_params(cls, verify_params: Vec[VerifyParam]):
-        pass
 
 
 def test_daf(Daf,

--- a/poc/vdaf.py
+++ b/poc/vdaf.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from functools import reduce
 import json
 import os
-from common import ERR_VERIFY, VERSION, Bytes, Error, Unsigned, Vec, \
-                   format_custom, gen_rand, to_le_bytes, \
-                   print_wrapped_line
+from common import ERR_VERIFY, VERSION, Bool, Bytes, Error, \
+                   Unsigned, Vec, format_custom, gen_rand, \
+                   to_le_bytes, print_wrapped_line
 import sagelib.field as field
 from sagelib.prg import PrgSha3
 from typing import Optional, Tuple, Union
@@ -51,9 +51,9 @@ class Vdaf:
     @classmethod
     def measurement_to_input_shares(Vdaf,
                                     measurement: Measurement,
-                                    nonce: Bytes[Vdaf.NONCE_SIZE],
-                                    rand: Bytes[Vdaf.RAND_SIZE],
-                                    ) -> (Bytes, Vec[Bytes]):
+                                    nonce: Bytes["Vdaf.NONCE_SIZE"],
+                                    rand: Bytes["Vdaf.RAND_SIZE"],
+                                    ) -> tuple[Bytes, Vec[Bytes]]:
         """
         Shard a measurement into a "public share" and a sequence of input
         shares, one for each Aggregator. This method is run by the Client.
@@ -75,7 +75,7 @@ class Vdaf:
                   agg_id: Unsigned,
                   agg_param: AggParam,
                   nonce: Bytes,
-                  public_share: Byhtes,
+                  public_share: Bytes,
                   input_share: Bytes) -> Prep:
         """
         Initialize the Prepare state for the given input share. This method is
@@ -413,7 +413,7 @@ def test_vdaf(Vdaf,
               print_test_vec=False,
               test_vec_instance=0):
     # Test that the algorithm identifier is in the correct range.
-    assert 0 <= Vdaf.ID and Vdaf.ID < 2^32
+    assert 0 <= Vdaf.ID and Vdaf.ID < 2 ** 32
 
     # Run the VDAF on the set of measurmenets.
     nonces = [gen_rand(Vdaf.NONCE_SIZE) for _ in range(len(measurements))]

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -17,7 +17,7 @@ from common import \
     to_be_bytes, \
     vec_add, \
     vec_sub
-from sagelib.vdaf import Vdaf, test_vdaf
+from vdaf import Vdaf, test_vdaf
 import sagelib.idpf as idpf
 import sagelib.idpf_poplar as idpf_poplar
 import sagelib.prg as prg

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -15,7 +15,7 @@ from common import \
     vec_add, \
     vec_sub, \
     zeros
-from sagelib.vdaf import Vdaf, test_vdaf
+from vdaf import Vdaf, test_vdaf
 import sagelib.flp as flp
 import sagelib.flp_generic as flp_generic
 import sagelib.prg as prg


### PR DESCRIPTION
This is part of #204. These two modules are mostly abstract base classes, so this conversion was straightforward.