### PR TITLE
Split up inputs and proofs in run_flp()

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1615,8 +1615,26 @@ def run_flp(Flp, inp: Vec[Flp.Field], num_shares: Unsigned):
     # Prover generates the proof.
     proof = Flp.prove(inp, prove_rand, joint_rand)
 
-    # Verifier queries the input and proof.
-    verifier = Flp.query(inp, proof, query_rand, joint_rand, num_shares)
+    # Shard the input and the proof.
+    input_shares = linear_secret_share(inp, num_shares, Flp.Field)
+    proof_shares = linear_secret_share(proof, num_shares, Flp.Field)
+
+    # Verifier queries the input shares and proof shares.
+    verifier_shares = [
+        Flp.query(
+            input_share,
+            proof_share,
+            query_rand,
+            joint_rand,
+            num_shares,
+        )
+        for input_share, proof_share in zip(input_shares, proof_shares)
+    ]
+
+    # Combine the verifier shares into the verifier.
+    verifier = Flp.Field.zeros(len(verifier_shares[0]))
+    for verifier_share in verifier_shares:
+        verifier = vec_add(verifier, verifier_share)
 
     # Verifier decides if the input is valid.
     return Flp.decide(verifier)

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -518,6 +518,11 @@ Some common functionalities:
 * `next_power_of_2(n: Unsigned) -> Unsigned` returns the smallest integer
   greater than or equal to `n` that is also a power of two.
 
+* `additive_secret_share(vec: Vec[Field], num_shares: Unsigned, field: type)
+  -> Vec[Vec[Field]]` takes a vector of field elements and returns multiple
+  vectors of the same length, such that they all add up to the input vector,
+  and each vector on its own is indistinguishable from uniform randomness.
+
 # Overview
 
 ~~~
@@ -1616,8 +1621,8 @@ def run_flp(Flp, inp: Vec[Flp.Field], num_shares: Unsigned):
     proof = Flp.prove(inp, prove_rand, joint_rand)
 
     # Shard the input and the proof.
-    input_shares = linear_secret_share(inp, num_shares, Flp.Field)
-    proof_shares = linear_secret_share(proof, num_shares, Flp.Field)
+    input_shares = additive_secret_share(inp, num_shares, Flp.Field)
+    proof_shares = additive_secret_share(proof, num_shares, Flp.Field)
 
     # Verifier queries the input shares and proof shares.
     verifier_shares = [

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -521,7 +521,7 @@ Some common functionalities:
 * `additive_secret_share(vec: Vec[Field], num_shares: Unsigned, field: type)
   -> Vec[Vec[Field]]` takes a vector of field elements and returns multiple
   vectors of the same length, such that they all add up to the input vector,
-  and each vector on its own is indistinguishable from uniform randomness.
+  and each proper subset of the vectors are indistinguishable from random.
 
 # Overview
 

--- a/poc/flp.sage
+++ b/poc/flp.sage
@@ -85,7 +85,9 @@ class Flp:
         return None
 
 
-def linear_secret_share(vec: Vec[Field], num_shares: Unsigned, field: type) -> Vec[Vec[Field]]:
+def additive_secret_share(vec: Vec[Field],
+                          num_shares: Unsigned,
+                          field: type) -> Vec[Vec[Field]]:
     shares = [
         field.rand_vec(len(vec))
         for _ in range(num_shares - 1)
@@ -109,8 +111,8 @@ def run_flp(Flp, inp: Vec[Flp.Field], num_shares: Unsigned):
     proof = Flp.prove(inp, prove_rand, joint_rand)
 
     # Shard the input and the proof.
-    input_shares = linear_secret_share(inp, num_shares, Flp.Field)
-    proof_shares = linear_secret_share(proof, num_shares, Flp.Field)
+    input_shares = additive_secret_share(inp, num_shares, Flp.Field)
+    proof_shares = additive_secret_share(proof, num_shares, Flp.Field)
 
     # Verifier queries the input shares and proof shares.
     verifier_shares = [

--- a/poc/flp_generic.sage
+++ b/poc/flp_generic.sage
@@ -647,7 +647,7 @@ def test_flp_generic(cls, test_cases):
                 cls.Valid.__name__, i, v))
 
         # Run the FLP.
-        decision = run_flp(cls, inp, 1)
+        decision = run_flp(cls, inp, 2)
         if decision != expected_decision:
             print('{}: test {} failed: proof evaluation resulted in {}; want {}'.format(
                 cls.Valid.__name__, i, decision, expected_decision))


### PR DESCRIPTION
This improves `run_flp()` to actually split the input and proof into shares, query each, and reassemble the verifier before running the decision algorithm.

Fixes #227.