### PR TITLE
Convert prg.sage to Python

### DIFF
--- a/poc/Makefile
+++ b/poc/Makefile
@@ -17,7 +17,7 @@ sagelib/%.py: %.sage
 test: pyfiles
 	sage -python common.py
 	sage field.sage
-	sage prg.sage
+	sage -python prg.py
 	sage -python flp.py
 	sage flp_generic.sage
 	sage -python idpf.py

--- a/poc/daf.py
+++ b/poc/daf.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from common import Bool, Bytes, Error, Unsigned, Vec, gen_rand
 from functools import reduce
 import sagelib.field as field
-from sagelib.prg import PrgSha3
+from prg import PrgSha3
 import json
 
 

--- a/poc/idpf.py
+++ b/poc/idpf.py
@@ -15,7 +15,7 @@ from functools import reduce
 import json
 import os
 import sagelib.field as field
-import sagelib.prg as prg
+import prg
 
 
 class Idpf:

--- a/poc/idpf_poplar.sage
+++ b/poc/idpf_poplar.sage
@@ -19,7 +19,7 @@ from common import \
 from sagelib.field import Field2
 from idpf import Idpf, gen_test_vec, test_idpf, test_idpf_exhaustive
 import sagelib.field as field
-from sagelib.prg import PrgFixedKeyAes128
+from prg import PrgFixedKeyAes128
 
 
 class IdpfPoplar(Idpf):

--- a/poc/vdaf.py
+++ b/poc/vdaf.py
@@ -8,7 +8,7 @@ from common import ERR_VERIFY, VERSION, Bool, Bytes, Error, \
                    Unsigned, Vec, format_dst, gen_rand, \
                    to_le_bytes, print_wrapped_line
 import sagelib.field as field
-from sagelib.prg import PrgSha3
+from prg import PrgSha3
 from typing import Optional, Tuple, Union
 
 

--- a/poc/vdaf_poplar1.sage
+++ b/poc/vdaf_poplar1.sage
@@ -20,7 +20,7 @@ from common import \
 from vdaf import Vdaf, test_vdaf
 import idpf
 import sagelib.idpf_poplar as idpf_poplar
-import sagelib.prg as prg
+import prg
 
 USAGE_SHARD_RAND = 1
 USAGE_CORR_INNER = 2

--- a/poc/vdaf_prio3.sage
+++ b/poc/vdaf_prio3.sage
@@ -18,7 +18,7 @@ from common import \
 from vdaf import Vdaf, test_vdaf
 import flp
 import sagelib.flp_generic as flp_generic
-import sagelib.prg as prg
+import prg
 
 USAGE_MEASUREMENT_SHARE = 1
 USAGE_PROOF_SHARE = 2


### PR DESCRIPTION
Part of #204. I replaced divisions that resulted in Sage rational numbers followed by `int()` casts with `__floordiv__` division. An int cast is needed when using `Field.ENCODED_SIZE`, as that's still a Sage integer for the time being, and some Pycryptodome methods using FFI calls are not tolerant of Sage integers.