### PR TITLE
Redefine Prio3Histogram measurement and parameters

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2657,25 +2657,21 @@ def Sum(inp: Vec[Field128], joint_rand: Vec[Field128]):
 
 ### Prio3Histogram
 
-This instance of Prio3 allows for estimating the distribution of the
-measurements by computing a simple histogram. Each measurement is an arbitrary
-integer and the aggregate result counts the number of measurements that fall in
-a set of fixed buckets.
+This instance of Prio3 allows for estimating a distribution of measurements by
+computing a simple histogram. Each measurement increments one histogram bucket,
+out of a set of fixed buckets. The aggregate result counts the number of
+measurements in each bucket.
 
 This instance of Prio3 uses PrgSha3 ({{prg-sha3}}) as its PRG. Its validity
-circuit, denoted `Histogram`, uses `Field128` ({{fields}}) as its finite
-field. The measurement is encoded as a one-hot vector representing the bucket
-into which the measurement falls (let `bucket` denote a sequence of
-monotonically increasing integers):
+circuit, denoted `Histogram`, uses `Field128` ({{fields}}) as its finite field.
+Let `length` be the number of histogram buckets. The measurement is encoded as a
+one-hot vector representing the bucket into which the measurement falls:
 
 ~~~
 def encode(Histogram, measurement: Integer):
-    boundaries = buckets + [math.inf]
-    encoded = [Field128(0) for _ in range(len(boundaries))]
-    for i in range(len(boundaries)):
-        if measurement <= boundaries[i]:
-            encoded[i] = Field128(1)
-            return encoded
+    encoded = [Field128(0)] * length
+    encoded[measurement] = Field128(1)
+    return encoded
 
 def truncate(Histogram, inp: Vec[Field128]):
     return inp
@@ -2714,9 +2710,9 @@ sharded. This is provided to the FLP by Prio3.
 | Parameter        | Value                   |
 |:-----------------|:------------------------|
 | `GADGETS`        | `[Range2]`              |
-| `GADGET_CALLS`   | `[buckets + 1]`         |
-| `INPUT_LEN`      | `buckets + 1`           |
-| `OUTPUT_LEN`     | `buckets + 1`           |
+| `GADGET_CALLS`   | `[length]`              |
+| `INPUT_LEN`      | `length`                |
+| `OUTPUT_LEN`     | `length`                |
 | `JOINT_RAND_LEN` | `2`                     |
 | `Measurement`    | `Integer`               |
 | `AggResult`      | `Vec[Unsigned]`         |
@@ -3858,10 +3854,10 @@ agg_result: 100
 {:numbered="false"}
 
 ~~~
-buckets: [1, 10, 100]
+length: 4
 verify_key: "000102030405060708090a0b0c0d0e0f"
 upload_0:
-  measurement: 50
+  measurement: 2
   nonce: "000102030405060708090a0b0c0d0e0f"
   public_share: >-
     5e015517900cfc204138c24f808ddf4ee85eca87ba246cd715d116195172e500

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2657,10 +2657,12 @@ def Sum(inp: Vec[Field128], joint_rand: Vec[Field128]):
 
 ### Prio3Histogram
 
-This instance of Prio3 allows for estimating a distribution of measurements by
-computing a simple histogram. Each measurement increments one histogram bucket,
-out of a set of fixed buckets. The aggregate result counts the number of
-measurements in each bucket.
+This instance of Prio3 allows for estimating the distribution of some quantity
+by computing a simple histogram. Each measurement increments one histogram
+bucket, out of a set of fixed buckets. For example, the buckets might quantize
+the real numbers, and each measurement would report the bucket that the
+corresponding client's real-numbered value falls into. The aggregate result
+counts the number of measurements in each bucket.
 
 This instance of Prio3 uses PrgSha3 ({{prg-sha3}}) as its PRG. Its validity
 circuit, denoted `Histogram`, uses `Field128` ({{fields}}) as its finite field.

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -493,11 +493,11 @@ class Prio3Histogram(Prio3):
     test_vec_name = 'Prio3Histogram'
 
     @classmethod
-    def with_buckets(Prio3Histogram, buckets: Vec[Unsigned]):
-        class Prio3HistogramWithBuckets(Prio3Histogram):
+    def with_length(Prio3Histogram, length: Unsigned):
+        class Prio3HistogramWithLength(Prio3Histogram):
             Flp = flp_generic.FlpGeneric \
-                    .with_valid(flp_generic.Histogram.with_buckets(buckets))
-        return Prio3HistogramWithBuckets
+                    .with_valid(flp_generic.Histogram.with_length(length))
+        return Prio3HistogramWithLength
 
 
 ##
@@ -554,17 +554,15 @@ if __name__ == '__main__':
     test_vdaf(cls, None, [100], 100, print_test_vec=TEST_VECTOR)
 
     cls = Prio3Histogram \
-            .with_buckets([1, 10, 100]) \
+            .with_length(4) \
             .with_shares(num_shares)
     assert cls.ID == 0x00000002
     test_vdaf(cls, None, [0], [1, 0, 0, 0])
-    test_vdaf(cls, None, [5], [0, 1, 0, 0])
-    test_vdaf(cls, None, [10], [0, 1, 0, 0])
-    test_vdaf(cls, None, [15], [0, 0, 1, 0])
-    test_vdaf(cls, None, [100], [0, 0, 1, 0])
-    test_vdaf(cls, None, [101], [0, 0, 0, 1])
-    test_vdaf(cls, None, [0, 1, 5, 10, 15, 100, 101, 101], [2, 2, 2, 2])
-    test_vdaf(cls, None, [50], [0, 0, 1, 0], print_test_vec=TEST_VECTOR)
+    test_vdaf(cls, None, [1], [0, 1, 0, 0])
+    test_vdaf(cls, None, [2], [0, 0, 1, 0])
+    test_vdaf(cls, None, [3], [0, 0, 0, 1])
+    test_vdaf(cls, None, [0, 0, 1, 1, 2, 2, 3, 3], [2, 2, 2, 2])
+    test_vdaf(cls, None, [2], [0, 0, 1, 0], print_test_vec=TEST_VECTOR)
 
     cls = TestPrio3Average.with_bits(3).with_shares(num_shares)
     test_vdaf(cls, None, [1, 5, 1, 1, 4, 1, 3, 2], 2)


### PR DESCRIPTION
This changes Prio3Histogram so that it is parameterized by a number of buckets, instead of a list of bucket boundaries. The measurement is now an index into the buckets, instead of an integer that's compared with the bucket boundaries. Closes #239. I confirmed that the messages in the Prio3Histogram test vector data are unchanged. (the parameter and measurement naturally changed)