### PR TITLE
Add "rand" input to test vectors

### DIFF
--- a/poc/vdaf.py
+++ b/poc/vdaf.py
@@ -191,6 +191,7 @@ def run_vdaf(Vdaf,
             Vdaf.measurement_to_input_shares(measurement, nonce, rand)
 
         # REMOVE ME
+        prep_test_vec['rand'] = rand.hex()
         prep_test_vec['public_share'] = public_share.hex()
         for input_share in input_shares:
             prep_test_vec['input_shares'].append(input_share.hex())


### PR DESCRIPTION
This adds the `rand` input to the machine-readable JSON test vectors, so that consumers don't have to implement its generation. This also opens the door to making randomness used in test vectors even more interesting. Closes #246.