### PR TITLE
Use verbs for API calls (#260)

### DIFF
--- a/poc/vdaf_poplar1.py
+++ b/poc/vdaf_poplar1.py
@@ -45,7 +45,7 @@ class Poplar1(Vdaf):
     test_vec_name = 'Poplar1'
 
     @classmethod
-    def measurement_to_input_shares(Poplar1, measurement, nonce, rand):
+    def shard(Poplar1, measurement, nonce, rand):
         l = Poplar1.Prg.SEED_SIZE
 
         # Split the random input into the random input for IDPF key
@@ -268,7 +268,7 @@ class Poplar1(Vdaf):
             raise ERR_INPUT  # unexpected input length
 
     @classmethod
-    def out_shares_to_agg_share(Poplar1, agg_param, out_shares):
+    def aggregate(Poplar1, agg_param, out_shares):
         (level, prefixes) = agg_param
         Field = Poplar1.Idpf.current_field(level)
         agg_share = Field.zeros(len(prefixes))
@@ -277,8 +277,8 @@ class Poplar1(Vdaf):
         return Field.encode_vec(agg_share)
 
     @classmethod
-    def agg_shares_to_result(Poplar1, agg_param,
-                             agg_shares, _num_measurements):
+    def unshard(Poplar1, agg_param,
+                agg_shares, _num_measurements):
         (level, prefixes) = agg_param
         Field = Poplar1.Idpf.current_field(level)
         agg = Field.zeros(len(prefixes))

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -41,7 +41,7 @@ class Prio3(Vdaf):
                  Bytes]           # k_joint_rand
 
     @classmethod
-    def measurement_to_input_shares(Prio3, measurement, nonce, rand):
+    def shard(Prio3, measurement, nonce, rand):
         l = Prio3.Prg.SEED_SIZE
         seeds = [rand[i:i+l] for i in range(0, Prio3.RAND_SIZE, l)]
 
@@ -129,15 +129,15 @@ class Prio3(Vdaf):
         return Prio3.encode_prep_msg(k_joint_rand_check)
 
     @classmethod
-    def out_shares_to_agg_share(Prio3, _agg_param, out_shares):
+    def aggregate(Prio3, _agg_param, out_shares):
         agg_share = Prio3.Flp.Field.zeros(Prio3.Flp.OUTPUT_LEN)
         for out_share in out_shares:
             agg_share = vec_add(agg_share, out_share)
         return Prio3.Flp.Field.encode_vec(agg_share)
 
     @classmethod
-    def agg_shares_to_result(Prio3, _agg_param,
-                             agg_shares, num_measurements):
+    def unshard(Prio3, _agg_param,
+                agg_shares, num_measurements):
         agg = Prio3.Flp.Field.zeros(Prio3.Flp.OUTPUT_LEN)
         for agg_share in agg_shares:
             agg = vec_add(agg, Prio3.Flp.Field.decode_vec(agg_share))


### PR DESCRIPTION
Closes #260.

Rename:
* measurement_to_input_shares -> shard
* out_shares_to_agg_share -> aggregate
* agg_shares_to_result -> unshard