### PR TITLE
Add Prio3SumVec

### DIFF
--- a/poc/flp.py
+++ b/poc/flp.py
@@ -68,13 +68,12 @@ class Flp:
         """Decode an aggregate result."""
         raise NotImplementedError()
 
-    def test_vec_set_type_param(self, test_vec):
+    def test_vec_set_type_param(self, test_vec) -> list[str]:
         """
         Add any parameters to `test_vec` that are required to construct this
-        class. Return the key that was set or `None` if `test_vec` was not
-        modified.
+        class. Returns the keys that were set.
         """
-        return None
+        return []
 
 
 def additive_secret_share(vec: Vec[Field],

--- a/poc/vdaf.py
+++ b/poc/vdaf.py
@@ -139,13 +139,12 @@ class Vdaf:
         return format_dst(0, Vdaf.ID, usage)
 
     @classmethod
-    def test_vec_set_type_param(Vdaf, test_vec):
+    def test_vec_set_type_param(Vdaf, test_vec) -> list[str]:
         """
         Add any parameters to `test_vec` that are required to construct this
-        class. Return the key that was set or `None` if `test_vec` was not
-        modified.
+        class. Returns the keys that were set.
         """
-        return None
+        return []
 
 
 # NOTE This is used to generate {{run-vdaf}}.
@@ -167,7 +166,7 @@ def run_vdaf(Vdaf,
         'agg_shares': [],
         'agg_result': None,  # set below
     }
-    type_param = Vdaf.test_vec_set_type_param(test_vec)
+    type_params = Vdaf.test_vec_set_type_param(test_vec)
 
     out_shares = []
     for (nonce, measurement) in zip(nonces, measurements):
@@ -175,7 +174,7 @@ def run_vdaf(Vdaf,
 
         # REMOVE ME
         prep_test_vec = {
-            'measurement': int(measurement),
+            'measurement': measurement,
             'nonce': nonce.hex(),
             'public_share': None,  # set below
             'input_shares': [],
@@ -264,7 +263,7 @@ def run_vdaf(Vdaf,
     # REMOVE ME
     test_vec['agg_result'] = agg_result
     if print_test_vec:
-        pretty_print_vdaf_test_vec(Vdaf, test_vec, type_param)
+        pretty_print_vdaf_test_vec(Vdaf, test_vec, type_params)
 
         os.system('mkdir -p test_vec/{:02}'.format(VERSION))
         with open('test_vec/{:02}/{}_{}.json'.format(
@@ -275,9 +274,9 @@ def run_vdaf(Vdaf,
     return agg_result
 
 
-def pretty_print_vdaf_test_vec(Vdaf, test_vec, type_param):
+def pretty_print_vdaf_test_vec(Vdaf, test_vec, type_params):
     print('---------- {} ---------------'.format(Vdaf.test_vec_name))
-    if type_param != None:
+    for type_param in type_params:
         print('{}: {}'.format(type_param, test_vec[type_param]))
     print('verify_key: "{}"'.format(test_vec['verify_key']))
     if test_vec['agg_param'] != None:

--- a/poc/vdaf_poplar1.py
+++ b/poc/vdaf_poplar1.py
@@ -372,7 +372,7 @@ class Poplar1(Vdaf):
     @classmethod
     def test_vec_set_type_param(cls, test_vec):
         test_vec['bits'] = int(cls.Idpf.BITS)
-        return 'bits'
+        return ['bits']
 
 
 if __name__ == '__main__':

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -529,6 +529,27 @@ class Prio3Histogram(Prio3):
         return Prio3HistogramWithLength
 
 
+class Prio3SumVec(Prio3):
+    # Generic types required by `Prio3`
+    Prg = prg.PrgSha3
+
+    # Associated parameters.
+    VERIFY_KEY_SIZE = prg.PrgSha3.SEED_SIZE
+    ID = 0x00000003
+
+    # Operational parameters.
+    test_vec_name = 'Prio3SumVec'
+
+    @classmethod
+    def with_params(Prio3SumVec, length: Unsigned, bits: Unsigned,
+                    chunk_length: Unsigned):
+        class Prio3SumVecWithParams(Prio3SumVec):
+            Flp = flp_generic.FlpGeneric(
+                flp_generic.SumVec(length, bits, chunk_length)
+            )
+        return Prio3SumVecWithParams
+
+
 ##
 # TESTS
 #
@@ -600,6 +621,39 @@ if __name__ == '__main__':
     cls = Prio3Histogram.with_length(4).with_shares(3)
     test_vdaf(cls, None, [2], [0, 0, 1, 0], print_test_vec=TEST_VECTOR,
               test_vec_instance=1)
+
+    cls = Prio3SumVec.with_params(10, 8, 9).with_shares(2)
+    assert cls.ID == 0x00000003
+    test_vdaf(
+        cls,
+        None,
+        [[1, 61, 86, 61, 23, 0, 255, 3, 2, 1]],
+        [1, 61, 86, 61, 23, 0, 255, 3, 2, 1]
+    )
+    test_vdaf(
+        cls,
+        None,
+        [
+            list(range(10)),
+            [1] * 10,
+            [255] * 10
+        ],
+        list(range(256, 266)),
+        print_test_vec=TEST_VECTOR,
+    )
+    cls = Prio3SumVec.with_params(3, 16, 7).with_shares(3)
+    test_vdaf(
+        cls,
+        None,
+        [
+            [10000, 32000, 9],
+            [19342, 19615, 3061],
+            [15986, 24671, 23910]
+        ],
+        [45328, 76286, 26980],
+        print_test_vec=TEST_VECTOR,
+        test_vec_instance=1,
+    )
 
     cls = TestPrio3Average.with_bits(3).with_shares(num_shares)
     test_vdaf(cls, None, [1, 5, 1, 1, 4, 1, 3, 2], 2)


### PR DESCRIPTION
This introduces the ParallelSum gadget and uses it in Prio3SumVec, which computes sums of vectors of integers.

This differs from the `Prio3SumVec` implementation that's been in libprio-rs for a while in three respects. First, the chunk length is now an explicit parameter, rather than being floor(sqrt(length * bits)). This both lets us dodge compatibility concerns about how exactly to compute that square root, and provides flexibility to squeeze a few more bytes out by using more optimal chunk length choices. (There are two different kinds of rounding involved in the proof size formula, plus there's a factor of two in front of the rounded number of calls) Second, libprio-rs defined a `BlindPolyEval(x, r) = r * p(x)` gadget for use in this validity circuit, but this PR just uses `Mul(x, y) = x * y` and extra affine gates on the inputs. This lets us keep the gadget's degree at two even when using the parallel sum gadget. We're still calculating the same random linear combination of $\sum_i {r^{i+1}(x_i^2-x_i)}$. Third, to pad out the inputs to the last ParallelSum invocation, I decided to substitute zero instead of substituting the measurement's last element. I figured that using zeros here is simpler.

Closes #124.