### PR TITLE
Replace SHAKE128 with TurboSHAKE128

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Install Sage
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "poc/draft-irtf-cfrg-kangarootwelve"]
+	path = poc/draft-irtf-cfrg-kangarootwelve
+	url = https://github.com/cfrg/draft-irtf-cfrg-kangarootwelve

--- a/poc/daf.py
+++ b/poc/daf.py
@@ -6,7 +6,7 @@ from functools import reduce
 
 import field
 from common import Bool, Unsigned, gen_rand
-from xof import XofShake128
+from xof import XofTurboShake128
 
 
 class Daf:
@@ -166,11 +166,11 @@ class TestDaf(Daf):
 
     @classmethod
     def shard(cls, measurement, _nonce, rand):
-        helper_shares = XofShake128.expand_into_vec(cls.Field,
-                                                    rand,
-                                                    b'',
-                                                    b'',
-                                                    cls.SHARES-1)
+        helper_shares = XofTurboShake128.expand_into_vec(cls.Field,
+                                                         rand,
+                                                         b'',
+                                                         b'',
+                                                         cls.SHARES-1)
         leader_share = cls.Field(measurement)
         for helper_share in helper_shares:
             leader_share -= helper_share

--- a/poc/vdaf_poplar1.py
+++ b/poc/vdaf_poplar1.py
@@ -328,7 +328,7 @@ class Poplar1(Vdaf):
         TheIdpf = idpf_poplar.IdpfPoplar \
             .with_value_len(2) \
             .with_bits(bits)
-        TheXof = xof.XofShake128
+        TheXof = xof.XofTurboShake128
 
         class Poplar1WithBits(Poplar1):
             Idpf = TheIdpf
@@ -414,28 +414,28 @@ if __name__ == '__main__':
         [2],
     )
     test_vdaf(
-        Poplar1.with_bits(128),
+        Poplar1.with_bits(64),
         (
-            127,
-            (from_be_bytes(b'0123456789abcdef'),),
+            63,
+            (from_be_bytes(b'01234567'),),
         ),
         [
-            from_be_bytes(b'0123456789abcdef'),
+            from_be_bytes(b'01234567'),
         ],
         [1],
     )
     test_vdaf(
-        Poplar1.with_bits(256),
+        Poplar1.with_bits(64),
         (
-            63,
+            31,
             (
-                from_be_bytes(b'00000000'),
-                from_be_bytes(b'01234567'),
+                from_be_bytes(b'0000'),
+                from_be_bytes(b'0123'),
             ),
         ),
         [
-            from_be_bytes(b'0123456789abcdef0123456789abcdef'),
-            from_be_bytes(b'01234567890000000000000000000000'),
+            from_be_bytes(b'01234567'),
+            from_be_bytes(b'01234000'),
         ],
         [0, 2],
     )

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -443,12 +443,12 @@ class Prio3(Vdaf):
 
 class Prio3Count(Prio3):
     # Generic types required by `Prio3`
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
     Flp = flp_generic.FlpGeneric(flp_generic.Count())
 
     # Associated parameters.
     ID = 0x00000000
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
 
     # Operational parameters.
     test_vec_name = 'Prio3Count'
@@ -456,10 +456,10 @@ class Prio3Count(Prio3):
 
 class Prio3Sum(Prio3):
     # Generic types required by `Prio3`
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
 
     # Associated parameters.
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
     ID = 0x00000001
 
     # Operational parameters.
@@ -474,10 +474,10 @@ class Prio3Sum(Prio3):
 
 class Prio3SumVec(Prio3):
     # Generic types required by `Prio3`
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
 
     # Associated parameters.
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
     ID = 0x00000002
 
     # Operational parameters.
@@ -495,10 +495,10 @@ class Prio3SumVec(Prio3):
 
 class Prio3Histogram(Prio3):
     # Generic types required by `Prio3`
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
 
     # Associated parameters.
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
     ID = 0x00000003
 
     # Operational parameters.
@@ -552,10 +552,10 @@ class Prio3SumVecWithMultiproof(Prio3SumVec):
 
 class Prio3MultiHotHistogram(Prio3):
     # Generic types required by `Prio3`
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
 
     # Associated parameters.
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
     # Private codepoint just for testing.
     ID = 0xFFFFFFFF
 
@@ -584,11 +584,11 @@ class TestPrio3Average(Prio3):
     class's decode() method.
     """
 
-    Xof = xof.XofShake128
+    Xof = xof.XofTurboShake128
     # NOTE 0xFFFFFFFF is reserved for testing. If we decide to standardize this
     # Prio3 variant, then we'll need to pick a real codepoint for it.
     ID = 0xFFFFFFFF
-    VERIFY_KEY_SIZE = xof.XofShake128.SEED_SIZE
+    VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
 
     @classmethod
     def with_bits(cls, bits: Unsigned):
@@ -650,7 +650,7 @@ if __name__ == '__main__':
     num_shares = 2  # Must be in range `[2, 256)`
 
     cls = Prio3 \
-        .with_xof(xof.XofShake128) \
+        .with_xof(xof.XofTurboShake128) \
         .with_flp(flp.FlpTestField128()) \
         .with_shares(num_shares)
     cls.ID = 0xFFFFFFFF
@@ -659,7 +659,7 @@ if __name__ == '__main__':
     # If JOINT_RAND_LEN == 0, then Fiat-Shamir isn't needed and we can skip
     # generating the joint randomness.
     cls = Prio3 \
-        .with_xof(xof.XofShake128) \
+        .with_xof(xof.XofTurboShake128) \
         .with_flp(flp.FlpTestField128.with_joint_rand_len(0)) \
         .with_shares(num_shares)
     cls.ID = 0xFFFFFFFF


### PR DESCRIPTION
Closes #299.

The reference code uses the reference implementation of TurboSHAKE128. This code is unoptimized, so care is needed to ensure our tests run in a reasonable amount of time.

Each time `XofTurboShake128` is constructed we call `TurboSHAKE128()` once and fill a buffer with the output stream. The size of the buffer is a constant, `MAX_XOF_OUT_STREAM_BYTES`, chosen to be sufficiently long for every test that we have. So that we don't have to make this value too large, some of tests in `vdaf_poplar1.py` have been modified.