### PR TITLE
Prio3: Improve domain separation for multi-proof mode

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2608,7 +2608,7 @@ def helper_proofs_share(Prio3, agg_id, k_share):
       Prio3.Flp.Field,
       k_share,
       Prio3.domain_separation_tag(USAGE_PROOF_SHARE),
-      byte(agg_id),
+      byte(Prio3.PROOFS) + byte(agg_id),
       Prio3.Flp.PROOF_LEN * Prio3.PROOFS,
   )
 
@@ -2624,7 +2624,7 @@ def prove_rands(Prio3, k_prove):
       Prio3.Flp.Field,
       k_prove,
       Prio3.domain_separation_tag(USAGE_PROVE_RANDOMNESS),
-      b'',
+      byte(Prio3.PROOFS),
       Prio3.Flp.PROVE_RAND_LEN * Prio3.PROOFS,
   )
 
@@ -2633,7 +2633,7 @@ def query_rands(Prio3, verify_key, nonce):
       Prio3.Flp.Field,
       verify_key,
       Prio3.domain_separation_tag(USAGE_QUERY_RANDOMNESS),
-      nonce,
+      byte(Prio3.PROOFS) + nonce,
       Prio3.Flp.QUERY_RAND_LEN * Prio3.PROOFS,
   )
 
@@ -2654,12 +2654,11 @@ def joint_rand_seed(Prio3, k_joint_rand_parts):
 
 def joint_rands(Prio3, k_joint_rand_seed):
   """Derive the joint randomness from its seed."""
-  binder = b'' if Prio3.PROOFS == 1 else byte(Prio3.PROOFS)
   return Prio3.Xof.expand_into_vec(
       Prio3.Flp.Field,
       k_joint_rand_seed,
       Prio3.domain_separation_tag(USAGE_JOINT_RANDOMNESS),
-      binder,
+      byte(Prio3.PROOFS),
       Prio3.Flp.JOINT_RAND_LEN * Prio3.PROOFS,
   )
 ~~~

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -300,7 +300,7 @@ class Prio3(Vdaf):
             Prio3.Flp.Field,
             k_share,
             Prio3.domain_separation_tag(USAGE_PROOF_SHARE),
-            byte(agg_id),
+            byte(Prio3.PROOFS) + byte(agg_id),
             Prio3.Flp.PROOF_LEN * Prio3.PROOFS,
         )
 
@@ -318,7 +318,7 @@ class Prio3(Vdaf):
             Prio3.Flp.Field,
             k_prove,
             Prio3.domain_separation_tag(USAGE_PROVE_RANDOMNESS),
-            b'',
+            byte(Prio3.PROOFS),
             Prio3.Flp.PROVE_RAND_LEN * Prio3.PROOFS,
         )
 
@@ -328,7 +328,7 @@ class Prio3(Vdaf):
             Prio3.Flp.Field,
             verify_key,
             Prio3.domain_separation_tag(USAGE_QUERY_RANDOMNESS),
-            nonce,
+            byte(Prio3.PROOFS) + nonce,
             Prio3.Flp.QUERY_RAND_LEN * Prio3.PROOFS,
         )
 
@@ -352,12 +352,11 @@ class Prio3(Vdaf):
     @classmethod
     def joint_rands(Prio3, k_joint_rand_seed):
         """Derive the joint randomness from its seed."""
-        binder = b'' if Prio3.PROOFS == 1 else byte(Prio3.PROOFS)
         return Prio3.Xof.expand_into_vec(
             Prio3.Flp.Field,
             k_joint_rand_seed,
             Prio3.domain_separation_tag(USAGE_JOINT_RANDOMNESS),
-            binder,
+            byte(Prio3.PROOFS),
             Prio3.Flp.JOINT_RAND_LEN * Prio3.PROOFS,
         )
 


### PR DESCRIPTION
Partially addresses #177.

The query randomness is correlated for different values of `Prio3.PROOFS`. To provide defense in depth in case the same verification key is used for different versions, prepend the binder with `bytes(Prio3.PROOFS)`.

For consistency, do the same for the prove randomness and each Helper's share of the proofs. Also, do the same for joint randomness in case `Prio3.PROOFS == 1`.