### PR TITLE
Fix metadata of informative references

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -135,7 +135,7 @@ informative:
 
   GKWWY20:
     title: Better concrete security for half-gates garbling (in the multi-instance setting)
-    authors:
+    author:
       - ins: C. Guo
       - ins: J. Katz
       - ins: X. Wang
@@ -147,7 +147,7 @@ informative:
 
   GKWY20:
     title: Efficient and Secure Multiparty Computation from Fixed-Key Block Ciphers
-    authors:
+    author:
       - ins: C. Guo
       - ins: J. Katz
       - ins: X. Wang


### PR DESCRIPTION
Closes #307. I noticed the following error messages when running `make`:

```
*** attributes left {"authors"=>[{"ins"=>"C. Guo"}, {"ins"=>"J. Katz"}, {"ins"=>"X. Wang"}, {"ins"=>"C. Weng"}, {"ins"=>"Y. Yu"}]}!
*** attributes left {"authors"=>[{"ins"=>"C. Guo"}, {"ins"=>"J. Katz"}, {"ins"=>"X. Wang"}, {"ins"=>"Y. Yu"}]}!
```