### PR TITLE
Infer relative path of kangerootwelve

### DIFF
--- a/poc/xof.py
+++ b/poc/xof.py
@@ -7,8 +7,10 @@ import sys
 
 from Cryptodome.Cipher import AES
 
-assert os.path.isdir('draft-irtf-cfrg-kangarootwelve/py')  # nopep8
-sys.path.append('draft-irtf-cfrg-kangarootwelve/py')  # nopep8
+kangarootwelve_path = \
+    "%s/draft-irtf-cfrg-kangarootwelve/py" % os.path.dirname(__file__)  # nopep8
+assert os.path.isdir(kangarootwelve_path)  # nopep8
+sys.path.append(kangarootwelve_path)  # nopep8
 from TurboSHAKE import TurboSHAKE128
 
 from common import (TEST_VECTOR, VERSION, Bytes, Unsigned, concat, format_dst,


### PR DESCRIPTION
This will resolve two problems:
- When another repo tries to submodule this repo, we won't hit problems when trying to import kangerootwelve
- We don't always have to run unit tests from the "poc" folder, e.g., I can still run unit tests from the root directory of this repo, sage -python poc/vdaf_prio3.py