### PR TITLE
Improvements to test vector generation

### DIFF
--- a/poc/README.md
+++ b/poc/README.md
@@ -6,7 +6,7 @@ themesleves.
 
 ## Installation
 
-This code is compatilbe with SageMath version 9.6.
+This code is compatible with SageMath version 9.6.
 
 In order to run the code you will need to install
 [PyCryptodome](https://pycryptodome.readthedocs.io/en/latest/index.html).
@@ -19,10 +19,20 @@ Version 3.20.0 or later is required.
 
 ## Generating test vectors
 
-To generate test vectors, set the value of `TEST_VECTOR` in `common.py` to
-`True` and run `make test`.
+To generate test vectors, set environmental variable `TEST_VECTOR` to
+be `TRUE` when running tests:
 
-> TODO Make this an environment variable.
+```
+make TEST_VECTOR=TRUE
+```
+
+Users can also specify a custom path to generate the test vectors in
+environmental variable `TEST_VECTOR_PATH`. For example, to generate
+test vectors for Prio3 VDAFs into path `test_vec/00`:
+
+```
+TEST_VECTOR=TRUE TEST_VECTOR_PATH=test_vec/00 sage -python vdaf_prio3.py
+```
 
 > TODO Pretty-print VDAF name, including associated parameters. (Right now we
 > print "<class '__main__.Prio3Aes128Histogram'>", which is rather ugly.)

--- a/poc/common.py
+++ b/poc/common.py
@@ -3,12 +3,15 @@
 import os
 from typing import List
 
-# If set, then test vectors will be generated. A fixed source of randomness is
-# used for `gen_rand()`.
-TEST_VECTOR = False
-
 # Document version, reved with each draft that contains breaking changes.
 VERSION = 8
+
+# If set, then test vectors will be generated. A fixed source of randomness is
+# used for `gen_rand()`.
+TEST_VECTOR = os.environ.get('TEST_VECTOR', 'false').lower() == 'true'
+# The path where test vectors are generated.
+TEST_VECTOR_PATH = os.environ.get('TEST_VECTOR_PATH',
+                                  'test_vec/{:02}'.format(VERSION))
 
 # Primitive types
 Bool = bool

--- a/poc/idpf.py
+++ b/poc/idpf.py
@@ -8,7 +8,7 @@ from functools import reduce
 from typing import Tuple, Union
 
 import field
-from common import VERSION, Bool, Bytes, Unsigned, gen_rand, vec_add
+from common import TEST_VECTOR_PATH, Bool, Bytes, Unsigned, gen_rand, vec_add
 
 
 class Idpf:
@@ -165,9 +165,9 @@ def gen_test_vec(Idpf, alpha, test_vec_instance):
         'keys': printable_keys,
     }
 
-    os.system('mkdir -p test_vec/{:02}'.format(VERSION))
-    with open('test_vec/{:02}/{}_{}.json'.format(
-            VERSION, Idpf.test_vec_name, test_vec_instance), 'w') as f:
+    os.system('mkdir -p {}'.format(TEST_VECTOR_PATH))
+    with open('{}/{}_{}.json'.format(
+            TEST_VECTOR_PATH, Idpf.test_vec_name, test_vec_instance), 'w') as f:
         json.dump(test_vec, f, indent=4, sort_keys=True)
         f.write('\n')
 

--- a/poc/vdaf.py
+++ b/poc/vdaf.py
@@ -6,8 +6,8 @@ import json
 import os
 from typing import Tuple, Union
 
-from common import (VERSION, Bool, Bytes, Unsigned, format_dst, gen_rand,
-                    print_wrapped_line, to_le_bytes)
+from common import (TEST_VECTOR_PATH, Bool, Bytes, Unsigned, format_dst,
+                    gen_rand, print_wrapped_line, to_le_bytes)
 
 
 class Vdaf:
@@ -308,9 +308,12 @@ def run_vdaf(Vdaf,
     if print_test_vec:
         pretty_print_vdaf_test_vec(Vdaf, test_vec, type_params)
 
-        os.system('mkdir -p test_vec/{:02}'.format(VERSION))
-        with open('test_vec/{:02}/{}_{}.json'.format(
-                VERSION, Vdaf.test_vec_name, test_vec_instance), 'w') as f:
+        os.system('mkdir -p {}'.format(TEST_VECTOR_PATH))
+        with open(
+            '{}/{}_{}.json'.format(
+                TEST_VECTOR_PATH, Vdaf.test_vec_name, test_vec_instance),
+            'w'
+        ) as f:
             json.dump(test_vec, f, indent=4, sort_keys=True)
             f.write('\n')
 

--- a/poc/xof.py
+++ b/poc/xof.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from Cryptodome.Cipher import AES
 from Cryptodome.Hash import TurboSHAKE128
 
-from common import (TEST_VECTOR, VERSION, Bytes, Unsigned, concat, format_dst,
-                    from_le_bytes, gen_rand, next_power_of_2,
+from common import (TEST_VECTOR, TEST_VECTOR_PATH, Bytes, Unsigned, concat,
+                    format_dst, from_le_bytes, gen_rand, next_power_of_2,
                     print_wrapped_line, to_le_bytes, xor)
 
 
@@ -238,7 +238,8 @@ if __name__ == '__main__':
             print('  expanded_vec_field128: >-')
             print_wrapped_line(test_vector['expanded_vec_field128'], tab=4)
 
-            os.system('mkdir -p test_vec/{:02}'.format(VERSION))
-            with open('test_vec/{:02}/{}.json'.format(VERSION, cls.__name__), 'w') as f:
+            os.system('mkdir -p {}'.format(TEST_VECTOR_PATH))
+            with open('{}/{}.json'.format(
+                    TEST_VECTOR_PATH, cls.__name__), 'w') as f:
                 json.dump(test_vector, f, indent=4, sort_keys=True)
                 f.write('\n')


### PR DESCRIPTION
Add an environmental variable TEST_VECTOR to control test vector generation, and an optional environmental variable TEST_VECTOR_PATH to specify a custom path where test vectors are generated. Add a new target in Makefile to generate all test vectors in VDAF spec.