### PR TITLE
Use Sage container image in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,11 @@ jobs:
   test:
     name: "Run unit tests for reference code"
     runs-on: ubuntu-latest
+    container: sagemath/sagemath:latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Install Sage
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y sagemath python3-cffi
-        sage -pip install pycryptodomex
 
     - name: Run tests
       working-directory: poc
-      run: make test
+      run: sage -python -m unittest


### PR DESCRIPTION
This uses a Sage Docker image in lieu of installing Sage with apt-get. This should hopefully speed up CI significantly. #330 enables this because our Makefile is now only two lines long, so we can duplicate the command in it, and use this container image that lacks GNU Make.