### PR TITLE
Replace generic `ERR_*` exceptions

### DIFF
--- a/poc/common.py
+++ b/poc/common.py
@@ -13,21 +13,6 @@ TEST_VECTOR_PATH = os.environ.get('TEST_VECTOR_PATH',
                                   'test_vec/{:02}'.format(VERSION))
 
 
-class Error(Exception):
-    """Base class for errors."""
-
-    def __init__(self, msg):
-        self.msg = msg
-
-
-# Errors
-ERR_ABORT = Error('algorithm aborted')
-ERR_DECODE = Error('decode failure')
-ERR_ENCODE = Error('encode failure')
-ERR_INPUT = Error('invalid input parameter')
-ERR_VERIFY = Error('verification of the user\'s input failed')
-
-
 def next_power_of_2(n):
     """Return the smallest power of 2 that is larger than or equal to n."""
     assert n > 0

--- a/poc/field.py
+++ b/poc/field.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sage.all import GF, PolynomialRing
 
-from common import ERR_DECODE, from_le_bytes, to_le_bytes
+from common import from_le_bytes, to_le_bytes
 
 
 class Field:
@@ -50,14 +50,16 @@ class Field:
         """
         L = Field.ENCODED_SIZE
         if len(encoded) % L != 0:
-            raise ERR_DECODE
+            raise ValueError(
+                'input length must be a multiple of the size of an '
+                'encoded field element')
 
         vec = []
         for i in range(0, len(encoded), L):
             encoded_x = encoded[i:i+L]
             x = from_le_bytes(encoded_x)
             if x >= Field.MODULUS:
-                raise ERR_DECODE  # Integer is larger than modulus
+                raise ValueError('modulus overflow')
             vec.append(Field(x))
         return vec
 

--- a/poc/tests/test_flp.py
+++ b/poc/tests/test_flp.py
@@ -1,7 +1,6 @@
 import unittest
 from copy import deepcopy
 
-from common import ERR_ENCODE
 from field import Field128
 from flp import Flp, run_flp
 
@@ -25,8 +24,6 @@ class FlpTest(Flp):
     meas_range = range(5)
 
     def encode(self, measurement):
-        if measurement not in self.meas_range:
-            raise ERR_ENCODE
         return [self.Field(measurement)] * 2
 
     def prove(self, meas, prove_rand, joint_rand):

--- a/poc/tests/test_flp_generic.py
+++ b/poc/tests/test_flp_generic.py
@@ -1,6 +1,6 @@
 import unittest
 
-from common import ERR_INPUT, next_power_of_2
+from common import next_power_of_2
 from field import Field64, Field96, Field128, poly_eval
 from flp import run_flp
 from flp_generic import (Count, FlpGeneric, Histogram, Mul, MultiHotHistogram,
@@ -28,13 +28,9 @@ class TestMultiGadget(Valid):
         return z
 
     def encode(self, measurement):
-        if measurement not in [0, 1]:
-            raise ERR_INPUT
         return [self.Field(measurement)]
 
     def truncate(self, meas):
-        if len(meas) != 1:
-            raise ERR_INPUT
         return meas
 
     def decode(self, output, _num_measurements):

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -5,8 +5,7 @@ from typing import Optional, Union
 import flp
 import flp_generic
 import xof
-from common import (ERR_INPUT, ERR_VERIFY, byte, concat, front, vec_add,
-                    vec_sub, zeros)
+from common import byte, concat, front, vec_add, vec_sub, zeros
 from vdaf import Vdaf
 
 USAGE_MEAS_SHARE = 1
@@ -117,10 +116,10 @@ class Prio3(Vdaf):
         k_joint_rand = prep_msg
         (out_share, k_corrected_joint_rand) = prep
 
-        # If joint randomness was used, check that the value computed by the
-        # Aggregators matches the value indicated by the Client.
+        # If joint randomness was used, check that the value computed by
+        # the Aggregators matches the value indicated by the Client.
         if k_joint_rand != k_corrected_joint_rand:
-            raise ERR_VERIFY  # joint randomness check failed
+            raise ValueError('joint randomness check failed')
 
         return out_share
 
@@ -139,7 +138,7 @@ class Prio3(Vdaf):
         for _ in range(Prio3.PROOFS):
             verifier, verifiers = front(Prio3.Flp.VERIFIER_LEN, verifiers)
             if not Prio3.Flp.decide(verifier):
-                raise ERR_VERIFY  # proof verifier check failed
+                raise ValueError('proof verifier check failed')
 
         # Combine the joint randomness parts computed by the
         # Aggregators into the true joint randomness seed. This is
@@ -363,8 +362,8 @@ class Prio3(Vdaf):
     def with_shares(Prio3, num_shares):
         assert Prio3.Xof is not None
         assert Prio3.Flp is not None
-        if num_shares < 2 or num_shares > 256:
-            raise ERR_INPUT
+        if num_shares not in range(2, 256):
+            raise ValueError('invalid number of shares')
         rand_size = (1+2*(num_shares-1)) * Prio3.Xof.SEED_SIZE
         if Prio3.Flp.JOINT_RAND_LEN > 0:
             rand_size += num_shares * Prio3.Xof.SEED_SIZE


### PR DESCRIPTION
Based on #350 (merge that first).

Closes #277.

Use a generic Python exception with a helpful error message. `ValueError` is the natural choice for all of our cases.