### PR TITLE
Add Prio3MultihotCountVec to the draft

### DIFF
--- a/poc/flp_generic.py
+++ b/poc/flp_generic.py
@@ -656,31 +656,31 @@ class Histogram(Valid):
         return ['length', 'chunk_length']
 
 
-class MultiHotHistogram(Valid):
-    r"""
-    A validity circuit that checks each Client's measurement is a bit vector
-    with at most `max_count` number of 1s.
-
-    In order to check the Client measurement `meas` has at most `max_count` 1s,
-    we ask the Client to send an additional `bits_for_count` bits that
-    encode the number of 1s in the measurement, with an offset. Specifically:
-    - Let `bits_for_count = max_count.bit_length()`, i.e. the number of bits
-      to represent `max_count`.
-    - Let `offset = 2**bits_for_count - 1 - max_count`.
-    - Client will encode `count = offset + \sum_i meas_i` in
-      `bits_for_count` bits.
-    - We can naturally bound `count` as the following:
-      `0 <= count <= 2**bits_for_count - 1`, and therefore:
-      `-offset <= \sum_i meas_i <= max_count`.
-    - Since we also verify each `meas_i` is a bit, we can lower bound the
-      summation by 0. Therefore, we will be able to verify
-      `0 <= \sum_i meas_i <= max_count`.
+class MultihotCountVec(Valid):
     """
-    # Operational parameters
-    length = None  # Set by the constructor
-    max_count = None  # Set by constructor
-    chunk_length = None  # Set by constructor
+    A validity circuit that checks each Client's measurement is a bit
+    vector with at most `max_weight` number of 1s. We call the number
+    of 1s in the vector the vector's "weight".
 
+    The circuit determines whether the weight of the vector is at most
+    `max_weight` as follows. First, it computes the weight of the
+    vector by summing the entries. Second, it compares the computed
+    weight to the weight reported by the Client and accepts the input
+    only if they are equal. Let
+
+    * `bits_for_weight = max_weight.bit_length()`
+    * `offset = 2**bits_for_weight - 1 - max_weight`
+
+    The reported weight is encoded by adding `offset` to it and
+    bit-encoding the result. Observe that only a value at most
+    `max_weight` can be encoded with `bits_for_weight` bits.
+
+    The verifier checks that each entry of the encoded measurement is
+    a bit (i.e., either one or zero). It then decodes the reported
+    weight and subtracts it from `offset + sum(count_vec)`, where
+    `count_vec` is the count vector. The result is zero if and only if
+    the reported weight is equal to the true weight.
+    """
     # Associated types
     Measurement = list[int]  # A vector of bits.
     AggResult = list[int]  # A vector of counts as unsigned integers.
@@ -689,44 +689,49 @@ class MultiHotHistogram(Valid):
     # Associated parameters
     JOINT_RAND_LEN = 2
 
-    def __init__(self, length, max_count, chunk_length):
+    def __init__(self, length, max_weight: int, chunk_length: int):
         """
-        Instantiate an instance of the `MultiHotHistogram` circuit with the
-        given length, max_count, and chunk_length.
+        Instantiate an instance of the this circuit with the given
+        `length`, `max_weight`, and `chunk_length`.
+
+        Pre-conditions:
+
+            - `length > 0`
+            - `0 < max_weight` and `max_weight <= length`
+            - `chunk_length > 0`
         """
         if length <= 0:
             raise ValueError('invalid length')
-        if max_count <= 0 or max_count > length:
-            raise ValueError('invalid max_count')
+        if max_weight <= 0 or max_weight > length:
+            raise ValueError('invalid max_weight')
         if chunk_length <= 0:
             raise ValueError('invalid chunk_length')
 
-        # Compute the number of bits to represent `max_count`.
-        self.bits_for_count = max_count.bit_length()
-        self.offset = self.Field((1 << self.bits_for_count) - 1 - max_count)
-        # Sanity check `offset + length` doesn't overflow field size,
-        # because in validity circuit, we will compute `offset + \sum_i meas_i`.
+        # Compute the number of bits to represent `max_weight`.
+        self.bits_for_weight = max_weight.bit_length()
+        self.offset = self.Field((2**self.bits_for_weight) - 1 - max_weight)
+
+        # Make sure `offset + length` doesn't overflow the field
+        # modulus. Otherwise we may not correctly compute the sum
+        # measurement vector entries during circuit evaluation.
         if self.Field.MODULUS - self.offset.as_unsigned() <= length:
-            raise ValueError('length and max_count are too large '
+            raise ValueError('length and max_weight are too large '
                              'for the current field size')
 
         self.length = length
-        self.max_count = max_count
+        self.max_weight = max_weight
         self.chunk_length = chunk_length
         self.GADGETS = [ParallelSum(Mul(), chunk_length)]
-        # The number of bit entries are `length + bits_for_count`,
-        # so the number of gadget calls is equal to
-        # `ceil((length + bits_for_count) / chunk_length)`.
         self.GADGET_CALLS = [
-            (length + self.bits_for_count + chunk_length - 1) // chunk_length
+            (length + self.bits_for_weight + chunk_length - 1) // chunk_length
         ]
-        self.MEAS_LEN = self.length + self.bits_for_count
+        self.MEAS_LEN = self.length + self.bits_for_weight
         self.OUTPUT_LEN = self.length
 
     def eval(self, meas, joint_rand, num_shares):
         self.check_valid_eval(meas, joint_rand)
 
-        # Check that each bucket is one or zero.
+        # Check that each entry in the input vector is one or zero.
         range_check = self.Field(0)
         r = joint_rand[0]
         r_power = r
@@ -747,28 +752,34 @@ class MultiHotHistogram(Valid):
 
             range_check += self.GADGETS[0].eval(self.Field, inputs)
 
-        # Check that `offset` plus the sum of the buckets is equal to the
-        # value claimed by the Client.
-        count_check = self.offset * shares_inv
-        for i in range(self.length):
-            count_check += meas[i]
-        count_check -= self.Field.decode_from_bit_vector(meas[self.length:])
+        # Check that the weight `offset` plus the sum of the counters
+        # is equal to the value claimed by the Client.
+        count_vec = meas[:self.length]
+        weight = sum(count_vec, self.Field(0))
+        weight_reported = \
+            self.Field.decode_from_bit_vector(meas[self.length:])
+        weight_check = self.offset*shares_inv + weight - \
+            weight_reported
 
         out = joint_rand[1] * range_check + \
-            joint_rand[1] ** 2 * count_check
+            joint_rand[1] ** 2 * weight_check
         return out
 
     def encode(self, measurement):
         if len(measurement) != self.length:
             raise ValueError('invalid Client measurement length')
 
-        encoded = list(map(self.Field, measurement))
-        # Encode the result of `offset + \sum_i measurement_i` into
-        # `bits_for_count` bits.
-        count = self.offset + sum(encoded, self.Field(0))
+        # The first part is the vector of counters.
+        count_vec = list(map(self.Field, measurement))
+
+        # The second part is the reported weight.
+        weight_reported = sum(count_vec, self.Field(0))
+
+        encoded = []
+        encoded += count_vec
         encoded += self.Field.encode_into_bit_vector(
-            count.as_unsigned(), self.bits_for_count
-        )
+            (self.offset + weight_reported).as_unsigned(),
+            self.bits_for_weight)
         return encoded
 
     def truncate(self, meas):
@@ -779,9 +790,9 @@ class MultiHotHistogram(Valid):
 
     def test_vec_set_type_param(self, test_vec):
         test_vec['length'] = int(self.length)
-        test_vec['max_count'] = int(self.max_count)
+        test_vec['max_weight'] = int(self.max_weight)
         test_vec['chunk_length'] = int(self.chunk_length)
-        return ['length', 'max_count', 'chunk_length']
+        return ['length', 'max_weight', 'chunk_length']
 
 
 class SumVec(Valid):

--- a/poc/tests/test_vdaf_prio3.py
+++ b/poc/tests/test_vdaf_prio3.py
@@ -7,7 +7,7 @@ from tests.test_flp import FlpTestField128
 from tests.test_flp_generic import TestAverage
 from tests.vdaf import test_vdaf
 from vdaf_prio3 import (Prio3, Prio3Count, Prio3Histogram,
-                        Prio3MultiHotHistogram, Prio3Sum, Prio3SumVec,
+                        Prio3MultihotCountVec, Prio3Sum, Prio3SumVec,
                         Prio3SumVecWithMultiproof)
 from xof import XofTurboShake128
 
@@ -168,25 +168,25 @@ class TestPrio3(unittest.TestCase):
             test_vec_instance=1,
         )
 
-    def test_multi_hot_histogram(self):
-        # Prio3MultiHotHistogram with length = 4, max_count = 2,
+    def test_multihot_count_vec(self):
+        # Prio3MultihotCountVec with length = 4, max_weight = 2,
         # chunk_length = 2.
-        cls = Prio3MultiHotHistogram \
+        cls = Prio3MultihotCountVec \
             .with_params(4, 2, 2) \
             .with_shares(2)
-        assert cls.ID == 0xFFFFFFFF
+        assert cls.ID == 0x00000004
         test_vdaf(cls, None, [[0, 0, 0, 0]], [0, 0, 0, 0])
         test_vdaf(cls, None, [[0, 1, 0, 0]], [0, 1, 0, 0])
         test_vdaf(cls, None, [[0, 1, 1, 0]], [0, 1, 1, 0])
         test_vdaf(cls, None, [[0, 1, 1, 0], [0, 1, 0, 1]], [0, 2, 1, 1])
         test_vdaf(
-            cls, None, [[0, 1, 1, 0]], [0, 1, 1, 0], print_test_vec=False
+            cls, None, [[0, 1, 1, 0]], [0, 1, 1, 0], print_test_vec=TEST_VECTOR
         )
 
     def test_multi_hot_histogram_3_shares(self):
-        # Prio3MultiHotHistogram with length = 11, max_count = 5,
+        # Prio3MultihotCountVec with length = 11, max_weight = 5,
         # chunk_length = 3.
-        cls = Prio3MultiHotHistogram.with_params(11, 5, 3).with_shares(3)
+        cls = Prio3MultihotCountVec.with_params(11, 5, 3).with_shares(3)
         test_vdaf(
             cls,
             None,

--- a/poc/vdaf_prio3.py
+++ b/poc/vdaf_prio3.py
@@ -568,22 +568,21 @@ class Prio3SumVecWithMultiproof(Prio3SumVec):
         return Prio3SumVecWithMultiproofAndParams
 
 
-class Prio3MultiHotHistogram(Prio3):
+class Prio3MultihotCountVec(Prio3):
     # Generic types required by `Prio3`
     Xof = xof.XofTurboShake128
 
     # Associated parameters.
     VERIFY_KEY_SIZE = xof.XofTurboShake128.SEED_SIZE
-    # Private codepoint just for testing.
-    ID = 0xFFFFFFFF
+    ID = 0x00000004
 
     # Operational parameters.
-    test_vec_name = 'Prio3MultiHotHistogram'
+    test_vec_name = 'Prio3MultihotCountVec'
 
     @classmethod
-    def with_params(Prio3MultiHotHistogram,
+    def with_params(cls,
                     length: int,
-                    max_count: int,
+                    max_weight: int,
                     chunk_length: int):
         """
         Set the circuit parameters.
@@ -591,11 +590,11 @@ class Prio3MultiHotHistogram(Prio3):
         Pre-conditions:
 
             - `length > 0`
-            - `max_count > 0`
+            - `max_weight > 0`
             - `chunk_length > 0`
         """
-        class Prio3MultiHotHistogramWithParams(Prio3MultiHotHistogram):
-            Flp = flp_generic.FlpGeneric(flp_generic.MultiHotHistogram(
-                length, max_count, chunk_length
+        class Prio3MultihotCountVecWithParams(cls):
+            Flp = flp_generic.FlpGeneric(flp_generic.MultihotCountVec(
+                length, max_weight, chunk_length
             ))
-        return Prio3MultiHotHistogramWithParams
+        return Prio3MultihotCountVecWithParams


### PR DESCRIPTION
Closes #287.

Assign Prio3MultiHotHistogram a codepoint (0x00000004) and add it to the draft under the name Prio3MultihotCountVec. Also, rename "count" to "weight", as in the "weight of the vector" (i.e., the number of non-zero entries).