### PR TITLE
Enforce type hints in field.py, xof.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install dependencies
-      run: sage --pip install pycryptodomex
+      run: sage --pip install pycryptodomex mypy
 
     - name: Run tests
       working-directory: poc
       run: sage -python -m unittest
+
+    - name: Enforce type hints
+      working-directory: poc
+      run: sage -python -m mypy xof.py field.py

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1857,7 +1857,7 @@ def derive_seed(Xof,
     xof = Xof(seed, dst, binder)
     return xof.next(Xof.SEED_SIZE)
 
-def next_vec(self, field: type, length: int):
+def next_vec(self, field: type[Field], length: int):
     """
     Output the next `length` field elements.
 
@@ -1867,7 +1867,7 @@ def next_vec(self, field: type, length: int):
         - `length > 0`
     """
     m = next_power_of_2(field.MODULUS) - 1
-    vec = []
+    vec: list[Field] = []
     while len(vec) < length:
         x = from_le_bytes(self.next(field.ENCODED_SIZE))
         x &= m

--- a/poc/field.py
+++ b/poc/field.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sage.all import GF, PolynomialRing
+from sage.all import GF, PolynomialRing  # type: ignore
 
 from common import ERR_DECODE, from_le_bytes, to_le_bytes
 

--- a/poc/xof.py
+++ b/poc/xof.py
@@ -6,6 +6,7 @@ from Cryptodome.Cipher import AES
 from Cryptodome.Hash import TurboSHAKE128
 
 from common import concat, from_le_bytes, next_power_of_2, to_le_bytes, xor
+from field import Field
 
 
 class Xof:
@@ -50,7 +51,7 @@ class Xof:
         xof = Xof(seed, dst, binder)
         return xof.next(Xof.SEED_SIZE)
 
-    def next_vec(self, field: type, length: int):
+    def next_vec(self, field: type[Field], length: int):
         """
         Output the next `length` field elements.
 
@@ -60,7 +61,7 @@ class Xof:
             - `length > 0`
         """
         m = next_power_of_2(field.MODULUS) - 1
-        vec = []
+        vec: list[Field] = []
         while len(vec) < length:
             x = from_le_bytes(self.next(field.ENCODED_SIZE))
             x &= m


### PR DESCRIPTION
Partially addresses #59.

Add type hint enforcement with mypy to CI, starting with field.py and xof.py. This checks that the variables passed into a function match the function's type hints.