### PR TITLE
Enforce type hints for flp.py, flp_generic.py, and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,5 @@ jobs:
 
     - name: Enforce type hints
       working-directory: poc
-      run: sage -python -m mypy xof.py field.py
+      # TODO(#59) run: sage -python -m mypy *.py tests/*.py
+      run: sage -python -m mypy xof.py field.py flp.py flp_generic.py tests/test_xof.py tests/test_field.py tests/test_flp.py tests/test_flp_generic.py

--- a/poc/flp.py
+++ b/poc/flp.py
@@ -1,17 +1,18 @@
 """Fully linear proof (FLP) systems."""
 
+from typing import Any
+
 import field
 from common import vec_add, vec_sub
-from field import Field
 
 
 class Flp:
     """The base class for FLPs."""
 
     # Generic paraemters
-    Measurement = None
-    AggResult = None
-    Field: field.Field = None
+    Measurement: Any = None
+    AggResult: Any = None
+    Field: Any = None
 
     # Length of the joint randomness shared by the prover and verifier.
     JOINT_RAND_LEN: int
@@ -111,9 +112,9 @@ class Flp:
         return []
 
 
-def additive_secret_share(vec: list[Field],
+def additive_secret_share(vec: list[field.Field],
                           num_shares: int,
-                          field: type) -> list[list[Field]]:
+                          field: type[field.Field]) -> list[list[field.Field]]:
     shares = [
         field.rand_vec(len(vec))
         for _ in range(num_shares - 1)
@@ -126,7 +127,7 @@ def additive_secret_share(vec: list[Field],
 
 
 # NOTE This is used to generate {{run-flp}}.
-def run_flp(flp, meas, num_shares):
+def run_flp(flp: Flp, meas: list[Flp.Field], num_shares: int):
     """Run the FLP on an encoded measurement."""
 
     joint_rand = flp.Field.rand_vec(flp.JOINT_RAND_LEN)


### PR DESCRIPTION
Partially addresses #59.

The "associated type" pattern we're trying to follow is not enforceable.
For example, we'll do something like this:

```
class Foo:
    Measurement = None
    def bar(self, m: Measurement): pass
```

`mypy` complains because `None` is not a valid type. We instead could do
the following:

```
class Foo:
    Measurement: Any = None
    def bar(self, m: Measurement): pass
```

A concrete sub-class would override this in the natural way:

```
class FooForInt(Foo):
    Measurement = int
    def bar(self, m: int): pass

Foo().bar(23)
Foo().bar("23")
FooForInt().bar(23)
FooForInt().bar("23") # fails
```