### PR TITLE
Check vector lengths when adding/subtracting

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1879,10 +1879,14 @@ def vec_sub(left: list[F], right: list[F]) -> list[F]:
     """
     Subtract the right operand from the left and return the result.
     """
+    if len(left) != len(right):
+        raise ValueError("mismatched vector sizes")
     return list(map(lambda x: x[0] - x[1], zip(left, right)))
 
 def vec_add(left: list[F], right: list[F]) -> list[F]:
     """Add the right operand to the left and return the result."""
+    if len(left) != len(right):
+        raise ValueError("mismatched vector sizes")
     return list(map(lambda x: x[0] + x[1], zip(left, right)))
 
 def vec_neg(vec: list[F]) -> list[F]:

--- a/poc/common.py
+++ b/poc/common.py
@@ -70,11 +70,15 @@ def vec_sub(left: list[F], right: list[F]) -> list[F]:
     """
     Subtract the right operand from the left and return the result.
     """
+    if len(left) != len(right):
+        raise ValueError("mismatched vector sizes")
     return list(map(lambda x: x[0] - x[1], zip(left, right)))
 
 
 def vec_add(left: list[F], right: list[F]) -> list[F]:
     """Add the right operand to the left and return the result."""
+    if len(left) != len(right):
+        raise ValueError("mismatched vector sizes")
     return list(map(lambda x: x[0] + x[1], zip(left, right)))
 
 


### PR DESCRIPTION
This adds some missing checks that vectors are of the same length in `vec_add()` and `vec_sub()`. The prose introducing these claims that "an exception is raised by each function if the operands are not the same length", but that wasn't true yet. `zip()` stops yielding when any input iterator does, so we need to explicitly check for this case.

```python
>>> list(zip([1], ['a', 'b']))
[(1, 'a')]
```