### PR TITLE
Remove HTML comment about Prio+

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1056,12 +1056,6 @@ task: Verification of the validity of the recovered output shares. This process
 ensures that aggregating the output shares will not lead to a garbled aggregate
 result.
 
-<!--
-For some VDAFs, like Prio3 ({{prio3}}) or Poplar1 ({{poplar1}}), the output
-shares are recovered first, then validated. For other protocols, like Prio+
-[AGJOP21], there is no explicit verification step.
--->
-
 The remainder of this section defines the VDAF interface. The attributes are
 listed in {{vdaf-param}} are defined by each concrete VDAF.
 


### PR DESCRIPTION
This text is superseded by the last paragraph of {{sec-vdaf-prepare}}, which says,

> The preparation-state update accomplishes two tasks: recovery of output shares
> from the input shares and ensuring that the recovered output shares are valid.
> The abstraction boundary is drawn so that an Aggregator only recovers an output
> share if it is deemed valid (at least, based on the Aggregator's view of the
> protocol). Another way to draw this boundary would be to have the Aggregators
> recover output shares first, then verify that they are valid. However, this
> would allow the possibility of misusing the API by, say, aggregating an invalid
> output share. Moreover, in protocols like Prio+ {{AGJOP21}} based on oblivious
> transfer, it is necessary for the Aggregators to interact in order to recover
> aggregatable output shares at all.