### PR TITLE
Set submission type to IRTF

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -6,6 +6,7 @@ category: info
 
 ipr: trust200902
 area: IRTF
+submissiontype: IRTF
 workgroup: CFRG
 keyword: Internet-Draft
 


### PR DESCRIPTION
This sets the submission type to IRTF. See https://datatracker.ietf.org/doc/html/rfc7991#appendix-A.2 for its definition. Note that `kramdown-rfc2629` supports this as one of three [aliases](https://github.com/cabo/kramdown-rfc/blob/6aef289cc6f39e1c851f92efbc69c4ac917c0537/data/kramdown-rfc2629.erb#L32) to set the `submissionType` attribute on the `<rfc>` tag. This clears up the following warning:

> Warning: Expected a valid submissionType (stream) setting, one of IETF, IAB, IRTF, independent, editorial, but found None.  Will use 'IETF'