### PR TITLE
Use parentheses around notes to RFC editor

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -222,8 +222,8 @@ measurement that would result in an invalid aggregate result.
 
 # Introduction
 
-[TO BE REMOVED BY RFC EDITOR: The source for this draft and and the reference
-implementation can be found at https://github.com/cfrg/draft-irtf-cfrg-vdaf.]
+(TO BE REMOVED BY RFC EDITOR: The source for this draft and and the reference
+implementation can be found at https://github.com/cfrg/draft-irtf-cfrg-vdaf.)
 
 The ubiquity of the Internet makes it an ideal platform for measurement of
 large-scale phenomena, whether public health trends or the behavior of computer
@@ -5411,8 +5411,8 @@ useful feedback on and contributions to the spec.
 # Test Vectors {#test-vectors}
 {:numbered="false"}
 
-[TO BE REMOVED BY RFC EDITOR: Machine-readable test vectors can be found at
-https://github.com/cfrg/draft-irtf-cfrg-vdaf/tree/main/poc/test_vec.]
+(TO BE REMOVED BY RFC EDITOR: Machine-readable test vectors can be found at
+https://github.com/cfrg/draft-irtf-cfrg-vdaf/tree/main/poc/test_vec.)
 
 Test vectors cover the generation of input shares and the conversion of input
 shares into output shares. Vectors specify the verification key, measurements,


### PR DESCRIPTION
Using square brackets around these notes causes Markdown issues. Rather than try to escape the brackets, I decided to use parentheses instead, because a quick Google search suggests parentheses are more common for these sorts of remarks.