### PR TITLE
Poplar1: On first prep round, handle none as error

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -4491,7 +4491,7 @@ def prep_next(
 
     if step == b'evaluate sketch':
         if prev_sketch is None:
-            prev_sketch = self.idpf.current_field(level).zeros(3)
+            raise ValueError('expected value, got none')
         elif len(prev_sketch) != 3:
             raise ValueError('incorrect sketch length')
         A_share = cast(Field, prep_mem[0])

--- a/poc/vdaf_poplar1.py
+++ b/poc/vdaf_poplar1.py
@@ -311,7 +311,7 @@ class Poplar1(
 
         if step == b'evaluate sketch':
             if prev_sketch is None:
-                prev_sketch = self.idpf.current_field(level).zeros(3)
+                raise ValueError('expected value, got none')
             elif len(prev_sketch) != 3:
                 raise ValueError('incorrect sketch length')
             A_share = cast(Field, prep_mem[0])


### PR DESCRIPTION
Closes #366.

The prep message type for Poplar1 is `Optional[FieldVec]`. The `None` variant is intended to be used in place of `[field(0)]`. This is the message we expect on the second round when the input is valid, so this saves a little bit of bandwidth.

We also use it in place of the length-3 vector of zeros. That is, if an Aggregator gets `None` in the first round, it will replace the message with `[field(0)] * 3` and proceed as if this is the message it received. However, in an honest execution of the protocol, the Aggregator will never receive `None` in the first round.

This commit modifies the behavior of `prep_next()` by treating this explicitly as an error. This change doesn't seem strictly necessary, as the all-zero vector is likely to be rejected, and in any case an attacker can always send the all-zero vector and trigger the same behavior. Nevertheless, it is security conservative as it eliminates a case we didn't intend.