### PR TITLE
Sync up descriptions of DAFs and VDAFs

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -894,7 +894,7 @@ been used with the same input share.
 
 DAFs MUST implement the following function:
 
-* `daf.is_valid(agg_param: AggParam, previous_agg_params: set[AggParam]) ->
+* `daf.is_valid(agg_param: AggParam, previous_agg_params: list[AggParam]) ->
   bool`: Checks if the `agg_param` is compatible with all elements of
   `previous_agg_params`.
 
@@ -1131,9 +1131,8 @@ the VDAF. (See {{xof}}.)
 
 ## Sharding {#sec-vdaf-shard}
 
-Sharding transforms a measurement into input shares as it does in DAFs
-(cf. {{sec-daf-shard}}); in addition, it takes a nonce as input and
-produces a public share:
+Sharding transforms a measurement and nonce into a public share and input shares
+as it does in DAFs (cf. {{sec-daf-shard}}):
 
 * `vdaf.shard(measurement: Measurement, nonce: bytes, rand: bytes) ->
   tuple[PublicShare, list[InputShare]]` is the randomized sharding algorithm

--- a/poc/daf.py
+++ b/poc/daf.py
@@ -72,7 +72,7 @@ class Daf(
     def is_valid(
             self,
             agg_param: AggParam,
-            previous_agg_params: set[AggParam]) -> bool:
+            previous_agg_params: list[AggParam]) -> bool:
         """
         Check if `agg_param` is valid for use with an input share that has
         previously been used with all `previous_agg_params`.

--- a/poc/tests/test_daf.py
+++ b/poc/tests/test_daf.py
@@ -51,7 +51,7 @@ class TestDaf(
     def is_valid(
             self,
             _agg_param: None,
-            _previous_agg_params: set[None]) -> bool:
+            _previous_agg_params: list[None]) -> bool:
         return True
 
     def prep(


### PR DESCRIPTION
This PR updates `is_valid()` for DAFs to take a list of previous aggregation parameters, following a similar change to VDAFs. It also updates the description of VDAF sharding to reflect that DAF sharding has the same sets of inputs and outputs.