### PR TITLE
Replace pseudocode for ping-pong topology with Python

### DIFF
--- a/poc/tests/test_vdaf_ping_pong.py
+++ b/poc/tests/test_vdaf_ping_pong.py
@@ -1,0 +1,252 @@
+import math
+import unittest
+from typing import Union, cast
+
+from vdaf_poc.common import from_be_bytes, to_be_bytes
+from vdaf_poc.test_utils import TestVdaf
+from vdaf_poc.vdaf import Vdaf
+from vdaf_poc.vdaf_ping_pong import Continued, Finished, PingPong
+
+
+class PingPongTester(
+        PingPong[
+            int,  # Measurement
+            int,  # AggParam,
+            str,  # PublicShare
+            int,  # InputShare
+            int,  # OutShare
+            int,  # AggShare
+            int,  # AggResult
+            tuple[int, int],  # PrepState
+            str,  # PrepShhare
+            str,  # PrepMessage
+        ]):
+    """
+    Computes the aggregation function f(agg_param, m[1], ..., m[N]) = agg_param
+    * (m[1] + ... + m[N]). This VDAF is not secure, but is sufficient to
+    exercise the code paths relevant to the ping pong topology.
+    """
+
+    ID: int = 0xFFFFFFFF
+    VERIFY_KEY_SIZE: int = 0
+    NONCE_SIZE: int = 0
+    RAND_SIZE: int = 0
+    SHARES: int = 2
+    ROUNDS: int
+
+    def __init__(self, num_rounds: int) -> None:
+        self.ROUNDS = num_rounds
+
+    # `Vdaf`
+
+    def shard(self,
+              measurement: int,
+              _nonce: bytes,
+              _rand: bytes) -> tuple[str, list[int]]:
+        return ('public share', [measurement, measurement])
+
+    def is_valid(self,
+                 agg_param: int,
+                 previous_agg_params: list[int]) -> bool:
+        return len(previous_agg_params) == 0
+
+    def prep_init(self,
+                  _verify_key: bytes,
+                  _agg_id: int,
+                  _agg_param: int,
+                  _nonce: bytes,
+                  public_share: str,
+                  input_share: int) -> tuple[tuple[int, int], str]:
+        if public_share != 'public share':
+            raise ValueError('unexpected public share')
+        current_round = 0
+        return (
+            (current_round, input_share),
+            'prep round {}'.format(current_round),
+        )
+
+    def prep_shares_to_prep(self,
+                            _agg_param: int,
+                            prep_shares: list[str]) -> str:
+        for prep_share in prep_shares[1:]:
+            if prep_share != prep_shares[0]:
+                raise ValueError('unexpected prep share')
+        return prep_shares[0]
+
+    def prep_next(self,
+                  prep_state: tuple[int, int],
+                  prep_msg: str) -> Union[tuple[tuple[int, int], str], int]:
+        (current_round, out_share) = prep_state
+        if prep_msg != "prep round {}".format(current_round):
+            raise ValueError("unexpted prep message")
+        if current_round+1 == self.ROUNDS:
+            return out_share
+        return (
+            (current_round+1, out_share),
+            "prep round {}".format(current_round+1),
+        )
+
+    def aggregate(self, _agg_param: int, out_shares: list[int]) -> int:
+        return sum(out_shares)
+
+    def unshard(self,
+                agg_param: int,
+                agg_shares: list[int],
+                _num_measurements: int) -> int:
+        return agg_param * sum(agg_shares) // self.SHARES
+
+    def test_vec_encode_input_share(self, input_share: int) -> bytes:
+        return to_be_bytes(input_share, 8)
+
+    def test_vec_encode_public_share(self, public_share: str) -> bytes:
+        return public_share.encode('utf-8')
+
+    def test_vec_encode_agg_share(self, agg_share: int) -> bytes:
+        return to_be_bytes(agg_share, 8)
+
+    def test_vec_encode_prep_share(self, prep_share: str) -> bytes:
+        return self.encode_prep_share(prep_share)
+
+    def test_vec_encode_prep_msg(self, prep_msg: str) -> bytes:
+        return self.encode_prep_msg(prep_msg)
+
+    # `PingPong`
+
+    def decode_public_share(self, encoded: bytes) -> str:
+        return encoded.decode('utf-8')
+
+    def decode_input_share(self, _agg_id: int, encoded: bytes) -> int:
+        return from_be_bytes(encoded)
+
+    def encode_prep_share(self, prep_share: str) -> bytes:
+        return prep_share.encode('utf-8')
+
+    def decode_prep_share(self,
+                          _prep_state: tuple[int, int],
+                          encoded: bytes) -> str:
+        return encoded.decode('utf-8')
+
+    def encode_prep_msg(self, prep_msg: str) -> bytes:
+        return prep_msg.encode('utf-8')
+
+    def decode_prep_msg(self,
+                        _prep_state: tuple[int, int],
+                        encoded: bytes) -> str:
+        return encoded.decode('utf-8')
+
+    def decode_agg_param(self, encoded: bytes) -> int:
+        return from_be_bytes(encoded)
+
+    def encode_agg_param(self, agg_param: int) -> bytes:
+        return to_be_bytes(agg_param, 8)
+
+
+class TestPingPongTester(TestVdaf):
+    def test(self) -> None:
+        """Ensure `PingPongTester` correctly implements the `Vdaf` API."""
+        self.run_vdaf_test(
+            cast(Vdaf, PingPongTester(10)),
+            23,  # agg_param,
+            [1, 2, 3, 4],  # measurements
+            10 * 23,  # expected_agg_result
+        )
+
+
+class TestPingPong(unittest.TestCase):
+    def test_one_round(self) -> None:
+        """Test the ping pong flow with a 1-round VDAF."""
+        vdaf = PingPongTester(1)
+        verify_key = b''
+
+        measurement = 1337
+        nonce = b''
+        rand = b''
+        (public_share, input_shares) = vdaf.shard(
+            measurement,
+            nonce,
+            rand,
+        )
+
+        agg_param = 23
+        (leader_state, msg) = vdaf.ping_pong_leader_init(
+            verify_key,
+            vdaf.encode_agg_param(agg_param),
+            nonce,
+            vdaf.test_vec_encode_public_share(public_share),
+            vdaf.test_vec_encode_input_share(input_shares[0]),
+        )
+        self.assertEqual(leader_state, Continued((0, measurement), 0))
+
+        (helper_state, msg) = vdaf.ping_pong_helper_init(
+            verify_key,
+            vdaf.encode_agg_param(agg_param),
+            nonce,
+            vdaf.test_vec_encode_public_share(public_share),
+            vdaf.test_vec_encode_input_share(input_shares[1]),
+            cast(bytes, msg),
+        )
+        self.assertEqual(helper_state, Finished(measurement))
+
+        (leader_state, msg) = vdaf.ping_pong_leader_continued(
+            vdaf.encode_agg_param(agg_param),
+            leader_state,
+            cast(bytes, msg),
+        )
+        self.assertEqual(msg, None)
+        self.assertEqual(leader_state, Finished(measurement))
+
+    def test_multi_round(self) -> None:
+        """Test the ping pong flow with multiple rounds."""
+        verify_key = b''
+        measurement = 1337
+        nonce = b''
+        rand = b''
+        agg_param = 23
+
+        for num_rounds in range(1, 10):
+            num_steps = math.ceil((num_rounds+1) / 2)
+
+            vdaf = PingPongTester(num_rounds)
+
+            (public_share, input_shares) = vdaf.shard(
+                measurement,
+                nonce,
+                rand,
+            )
+
+            (leader_state, msg) = vdaf.ping_pong_leader_init(
+                verify_key,
+                vdaf.encode_agg_param(agg_param),
+                nonce,
+                vdaf.test_vec_encode_public_share(public_share),
+                vdaf.test_vec_encode_input_share(input_shares[0]),
+            )
+            self.assertEqual(leader_state, Continued((0, measurement), 0))
+
+            for step in range(num_steps):
+                if step == 0:
+                    (helper_state, msg) = vdaf.ping_pong_helper_init(
+                        verify_key,
+                        vdaf.encode_agg_param(agg_param),
+                        nonce,
+                        vdaf.test_vec_encode_public_share(public_share),
+                        vdaf.test_vec_encode_input_share(input_shares[1]),
+                        cast(bytes, msg),
+                    )
+                else:
+                    (helper_state, msg) = vdaf.ping_pong_helper_continued(
+                        vdaf.encode_agg_param(agg_param),
+                        helper_state,
+                        cast(bytes, msg),
+                    )
+
+                if isinstance(leader_state, Continued):
+                    (leader_state, msg) = vdaf.ping_pong_leader_continued(
+                        vdaf.encode_agg_param(agg_param),
+                        leader_state,
+                        cast(bytes, msg),
+                    )
+
+            self.assertEqual(msg, None)
+            self.assertEqual(leader_state, Finished(measurement))
+            self.assertEqual(helper_state, Finished(measurement))

--- a/poc/vdaf_poc/vdaf_ping_pong.py
+++ b/poc/vdaf_poc/vdaf_ping_pong.py
@@ -1,0 +1,296 @@
+"""Ping-pong topology for VDAFs."""
+
+from abc import ABCMeta, abstractmethod
+from typing import Generic, Optional, TypeVar, cast
+
+from vdaf_poc.common import byte, from_be_bytes, front, to_be_bytes
+from vdaf_poc.vdaf import Vdaf
+
+Measurement = TypeVar("Measurement")
+AggParam = TypeVar("AggParam")
+PublicShare = TypeVar("PublicShare")
+InputShare = TypeVar("InputShare")
+OutShare = TypeVar("OutShare")
+AggShare = TypeVar("AggShare")
+AggResult = TypeVar("AggResult")
+PrepState = TypeVar("PrepState")
+PrepShare = TypeVar("PrepShare")
+PrepMessage = TypeVar("PrepMessage")
+
+# NOTE: Classes State, Start, Continued, Finished, and Rejected are exerpted in
+# the document. Their width should be limited to 69 columns to avoid warnings
+# from xml2rfc.
+# ===================================================================
+
+
+class State:
+    pass
+
+
+class Start(State):
+    pass
+
+
+class Continued(State, Generic[PrepState]):
+    def __init__(self, prep_state: PrepState, prep_round: int):
+        self.prep_state = prep_state
+        self.prep_round = prep_round
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Continued) and \
+            self.prep_state == other.prep_state and \
+            self.prep_round == other.prep_round
+
+
+class Finished(State, Generic[OutShare]):
+    def __init__(self, out_share: OutShare):
+        self.out_share = out_share
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Finished) and \
+            self.out_share == other.out_share
+
+
+class Rejected(State):
+    pass
+
+
+class PingPong(
+        Vdaf[
+            Measurement,
+            AggParam,
+            PublicShare,
+            InputShare,
+            OutShare,
+            AggShare,
+            AggResult,
+            PrepState,
+            PrepShare,
+            PrepMessage,
+        ],
+        metaclass=ABCMeta):
+
+    @abstractmethod
+    def decode_public_share(self, encoded: bytes) -> PublicShare:
+        pass
+
+    @abstractmethod
+    def decode_input_share(self, agg_id: int, encoded: bytes) -> InputShare:
+        pass
+
+    @abstractmethod
+    def encode_prep_share(self, prep_share: PrepShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_prep_share(self, prep_state: PrepState, encoded: bytes) -> PrepShare:
+        pass
+
+    @abstractmethod
+    def encode_prep_msg(self, prep_msg: PrepMessage) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_prep_msg(self, prep_state: PrepState, encoded: bytes) -> PrepMessage:
+        pass
+
+    @abstractmethod
+    def decode_agg_param(self, encoded: bytes) -> AggParam:
+        pass
+
+    # NOTE: Methods ping_pong_leader_init(), ping_pong_helper_init(),
+    # ping_pong_transition(), ping_pong_leader_continued(),
+    # ping_pong_continued(), and ping_pong_helper_continued() are excerpted in
+    # the document, de-indented. Their width should be limited to 69 columns
+    # after de-indenting, or 73 columns before de-indenting, to avoid warnings
+    # from xml2rfc.
+    # ===================================================================
+    def ping_pong_leader_init(
+            self,
+            vdaf_verify_key: bytes,
+            agg_param: bytes,
+            nonce: bytes,
+            public_share: bytes,
+            input_share: bytes) -> tuple[State, Optional[bytes]]:
+        """Called by the leader to initialize ping-ponging."""
+        try:
+            (prep_state, prep_share) = self.prep_init(
+                vdaf_verify_key,
+                0,
+                self.decode_agg_param(agg_param),
+                nonce,
+                self.decode_public_share(public_share),
+                self.decode_input_share(0, input_share),
+            )
+            encoded_prep_share = self.encode_prep_share(prep_share)
+            return (
+                Continued(prep_state, 0),
+                encode(0, encoded_prep_share),  # initialize
+            )
+        except:
+            return (Rejected(), None)
+
+    def ping_pong_helper_init(
+            self,
+            vdaf_verify_key: bytes,
+            agg_param: bytes,
+            nonce: bytes,
+            public_share: bytes,
+            input_share: bytes,
+            inbound: bytes) -> tuple[State, Optional[bytes]]:
+        """
+        Called by the helper in response to the leader's initial
+        message.
+        """
+        try:
+            (prep_state, prep_share) = self.prep_init(
+                vdaf_verify_key,
+                1,
+                self.decode_agg_param(agg_param),
+                nonce,
+                self.decode_public_share(public_share),
+                self.decode_input_share(1, input_share),
+            )
+
+            (inbound_type, inbound_items) = decode(inbound)
+            if inbound_type != 0:  # initialize
+                return (Rejected(), None)
+
+            encoded_prep_share = inbound_items[0]
+            prep_shares = [
+                self.decode_prep_share(prep_state, encoded_prep_share),
+                prep_share,
+            ]
+            return self.ping_pong_transition(
+                self.decode_agg_param(agg_param),
+                prep_shares,
+                prep_state,
+                0,
+            )
+        except:
+            return (Rejected(), None)
+
+    def ping_pong_transition(
+            self,
+            agg_param: AggParam,
+            prep_shares: list[PrepShare],
+            prep_state: PrepState,
+            prep_round: int) -> tuple[State, bytes]:
+        prep_msg = self.prep_shares_to_prep(agg_param,
+                                            prep_shares)
+        encoded_prep_msg = self.encode_prep_msg(prep_msg)
+        out = self.prep_next(prep_state, prep_msg)
+        if prep_round+1 == self.ROUNDS:
+            return (
+                Finished(out),
+                encode(2, encoded_prep_msg),  # finalize
+            )
+        (prep_state, prep_share) = cast(
+            tuple[PrepState, PrepShare], out)
+        encoded_prep_share = self.encode_prep_share(prep_share)
+        return (
+            Continued(prep_state, prep_round+1),
+            encode(1, encoded_prep_msg, encoded_prep_share)  # continue
+        )
+
+    def ping_pong_leader_continued(
+        self,
+        agg_param: bytes,
+        state: State,
+        inbound: bytes,
+    ) -> tuple[State, Optional[bytes]]:
+        """
+        Called by the leader to start the next step of ping-ponging.
+        """
+        return self.ping_pong_continued(
+            True, agg_param, state, inbound)
+
+    def ping_pong_continued(
+        self,
+        is_leader: bool,
+        agg_param: bytes,
+        state: State,
+        inbound: bytes,
+    ) -> tuple[State, Optional[bytes]]:
+        try:
+            if not isinstance(state, Continued):
+                return (Rejected(), None)
+            prep_round = state.prep_round
+
+            (inbound_type, inbound_items) = decode(inbound)
+            if inbound_type == 0:  # initialize
+                return (Rejected(), None)
+
+            encoded_prep_msg = inbound_items[0]
+            prep_msg = self.decode_prep_msg(
+                state.prep_state,
+                encoded_prep_msg,
+            )
+            out = self.prep_next(state.prep_state, prep_msg)
+            if prep_round+1 < self.ROUNDS and \
+                    inbound_type == 1:  # continue
+                (prep_state, prep_share) = cast(
+                    tuple[PrepState, PrepShare], out)
+                encoded_prep_share = inbound_items[1]
+                prep_shares = [
+                    self.decode_prep_share(
+                        prep_state,
+                        encoded_prep_share,
+                    ),
+                    prep_share,
+                ]
+                if is_leader:
+                    prep_shares.reverse()
+                return self.ping_pong_transition(
+                    self.decode_agg_param(agg_param),
+                    prep_shares,
+                    prep_state,
+                    prep_round+1,
+                )
+            elif prep_round+1 == self.ROUNDS and \
+                    inbound_type == 2:  # finish
+                return (Finished(out), None)
+            else:
+                return (Rejected(), None)
+        except:
+            return (Rejected(), None)
+
+    def ping_pong_helper_continued(
+        self,
+        agg_param: bytes,
+        state: State,
+        inbound: bytes,
+    ) -> tuple[State, Optional[bytes]]:
+        """Called by the helper to continue ping-ponging."""
+        return self.ping_pong_continued(
+            False, agg_param, state, inbound)
+
+
+def encode(msg_type: int, *items: bytes) -> bytes:
+    encoded = bytes()
+    encoded += byte(msg_type)
+    for item in items:
+        encoded += to_be_bytes(len(item), 4)
+        encoded += item
+    return encoded
+
+
+def decode(encoded: bytes) -> tuple[int, list[bytes]]:
+    ([msg_type], encoded) = front(1, encoded)
+    if msg_type == 0:    # initialize
+        num_counts = 1   # prep_share
+    elif msg_type == 1:  # continue
+        num_counts = 2   # prep_msg, prep_share
+    elif msg_type == 2:  # finish
+        num_counts = 1   # prep_msg
+    else:
+        raise ValueError('unexpected message type: {}'.format(msg_type))
+    items = []
+    for _ in range(num_counts):
+        (encoded_item_len, encoded) = front(4, encoded)
+        item_len = from_be_bytes(encoded_item_len)
+        (item, encoded) = front(item_len, encoded)
+        items.append(item)
+    if len(encoded) > 0:
+        raise ValueError('unexpected message length')
+    return (int(msg_type), items)


### PR DESCRIPTION
Closes #283.
Based on #386 (merge that first).

Add an implementation of the ping-pong API to the reference code. The
pseudocode currently in the draft doesn't compile, so replace it with
the tested, type-checked, and linted Python.

Also, in the draft, we don't need to list the encoding methods used by
the ping-pong API; these should be clear in context.