### PR TITLE
tls-presentation: Fix limits for length-prefixed values

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1582,17 +1582,18 @@ struct {
   MessageType type;
   select (Message.type) {
     case initialize:
-      opaque prep_share<0..2^32-1>;
+      opaque prep_share<1..2^32-1>;
     case continue:
       opaque prep_msg<0..2^32-1>;
-      opaque prep_share<0..2^32-1>;
+      opaque prep_share<1..2^32-1>;
     case finish:
       opaque prep_msg<0..2^32-1>;
   };
 } Message;
 ~~~
 
-These messages are used to transition between the states described in
+Note that the shortest encodable ping-pong message is `5` bytes long. These
+messages are used to transition between the states described in
 {{vdaf-prep-comm}}. The Leader's initial transition is computed with the
 following method, implemented on `Vdaf`:
 


### PR DESCRIPTION
Assume the length of the encoded prep share is at least 1 byte for every VDAF; otherwise there would be no mechanism to convey validity. The prep message, however, may be empty, as it is for some Prio3 variants.