### PR TITLE
Remove `k_` prefix from seed variables

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2764,7 +2764,7 @@ def shard_with_joint_rand(
         helper_seeds[i]
         for i in range(1, (self.SHARES - 1) * 2, 2)
     ]
-    (leader_blind, prove), seeds = front(2, seeds)
+    (leader_blind, prove_seed), seeds = front(2, seeds)
 
     # Shard the encoded measurement into shares and compute the
     # joint randomness parts.
@@ -2782,7 +2782,7 @@ def shard_with_joint_rand(
         ctx, 0, leader_blind, leader_meas_share, nonce))
 
     # Generate the proof and shard it into proof shares.
-    prove_rands = self.prove_rands(ctx, prove)
+    prove_rands = self.prove_rands(ctx, prove_seed)
     joint_rands = self.joint_rands(
         ctx, self.joint_rand_seed(ctx, joint_rand_parts))
     leader_proofs_share = []
@@ -2897,16 +2897,17 @@ def prep_init(
 
     # Compute the joint randomness.
     joint_rand: list[F] = []
-    corrected_joint_rand, joint_rand_part = None, None
+    corrected_joint_rand_seed, joint_rand_part = None, None
     if self.flp.JOINT_RAND_LEN > 0:
         assert blind is not None
         assert joint_rand_parts is not None
         joint_rand_part = self.joint_rand_part(
             ctx, agg_id, blind, meas_share, nonce)
         joint_rand_parts[agg_id] = joint_rand_part
-        corrected_joint_rand = self.joint_rand_seed(
+        corrected_joint_rand_seed = self.joint_rand_seed(
             ctx, joint_rand_parts)
-        joint_rands = self.joint_rands(ctx, corrected_joint_rand)
+        joint_rands = self.joint_rands(
+            ctx, corrected_joint_rand_seed)
 
     # Query the measurement and proof share.
     query_rands = self.query_rands(verify_key, ctx, nonce)
@@ -2927,7 +2928,7 @@ def prep_init(
             self.SHARES,
         )
 
-    prep_state = (out_share, corrected_joint_rand)
+    prep_state = (out_share, corrected_joint_rand_seed)
     prep_share = (verifiers_share, joint_rand_part)
     return (prep_state, prep_share)
 
@@ -2937,12 +2938,12 @@ def prep_next(
     prep_state: Prio3PrepState[F],
     prep_msg: Optional[bytes]
 ) -> tuple[Prio3PrepState[F], Prio3PrepShare[F]] | list[F]:
-    joint_rand = prep_msg
-    (out_share, corrected_joint_rand) = prep_state
+    joint_rand_seed = prep_msg
+    (out_share, corrected_joint_rand_seed) = prep_state
 
     # If joint randomness was used, check that the value computed by
     # the Aggregators matches the value indicated by the Client.
-    if joint_rand != corrected_joint_rand:
+    if joint_rand_seed != corrected_joint_rand_seed:
         raise ValueError('joint randomness check failed')
 
     return out_share
@@ -2971,10 +2972,10 @@ def prep_shares_to_prep(
     # Combine the joint randomness parts computed by the
     # Aggregators into the true joint randomness seed. This is
     # used in the last step.
-    joint_rand = None
+    joint_rand_seed = None
     if self.flp.JOINT_RAND_LEN > 0:
-        joint_rand = self.joint_rand_seed(ctx, joint_rand_parts)
-    return joint_rand
+        joint_rand_seed = self.joint_rand_seed(ctx, joint_rand_parts)
+    return joint_rand_seed
 ~~~
 {: #prio3-prep-state title="Preparation state for Prio3."}
 
@@ -3083,10 +3084,10 @@ def expand_input_share(
         (meas_share, proofs_share, blind) = input_share
     return (meas_share, proofs_share, blind)
 
-def prove_rands(self, ctx: bytes, prove: bytes) -> list[F]:
+def prove_rands(self, ctx: bytes, prove_seed: bytes) -> list[F]:
     return self.xof.expand_into_vec(
         self.flp.field,
-        prove,
+        prove_seed,
         self.domain_separation_tag(USAGE_PROVE_RANDOMNESS, ctx),
         byte(self.PROOFS),
         self.flp.PROVE_RAND_LEN * self.PROOFS,

--- a/poc/vdaf_poc/vdaf_poplar1.py
+++ b/poc/vdaf_poc/vdaf_poplar1.py
@@ -91,10 +91,10 @@ class Poplar1(
         idpf_rand, rand = front(self.idpf.RAND_SIZE, rand)
         seeds = [rand[i:i + l] for i in range(0, 3 * l, l)]
         corr_seed, seeds = front(2, seeds)
-        (k_shard,), seeds = front(1, seeds)
+        (shard_seed,), seeds = front(1, seeds)
 
         xof = self.xof(
-            k_shard,
+            shard_seed,
             self.domain_separation_tag(USAGE_SHARD_RAND, ctx),
             nonce,
         )


### PR DESCRIPTION
Closes #435.

Also, add a `_seed` suffix where the new variable name is confusing: `k_prove` -> `prove_seed` in Prio3; and `k_shard` -> `shard_seed` in Poplar1.