### PR TITLE
Replace `aggregate()` with streaming API

### DIFF
--- a/poc/tests/test_daf.py
+++ b/poc/tests/test_daf.py
@@ -70,11 +70,19 @@ class TestDaf(
         # share.
         return input_share
 
-    def aggregate(
-            self,
-            _agg_param: None,
-            out_shares: list[Field128]) -> Field128:
-        return reduce(lambda x, y: x + y, out_shares)
+    def agg_init(self, _agg_param: None) -> Field128:
+        return Field128(0)
+
+    def agg_update(self,
+                   _agg_param: None,
+                   agg_share: Field128,
+                   out_share: Field128) -> Field128:
+        return agg_share + out_share
+
+    def merge(self,
+              _agg_param: None,
+              agg_shares: list[Field128]) -> Field128:
+        return reduce(lambda x, y: x + y, agg_shares)
 
     def unshard(
             self,

--- a/poc/tests/test_vdaf_ping_pong.py
+++ b/poc/tests/test_vdaf_ping_pong.py
@@ -90,8 +90,19 @@ class PingPongTester(
             "prep round {}".format(current_round+1),
         )
 
-    def aggregate(self, _agg_param: int, out_shares: list[int]) -> int:
-        return sum(out_shares)
+    def agg_init(self, _agg_param: int) -> int:
+        return 0
+
+    def agg_update(self,
+                   _agg_param: int,
+                   agg_share: int,
+                   agg_delta: int) -> int:
+        return agg_share + agg_delta
+
+    def merge(self,
+              _agg_param: int,
+              _agg_shares: list[int]) -> int:
+        raise NotImplementedError("not needed by tests")
 
     def unshard(self,
                 agg_param: int,

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -221,7 +221,9 @@ def gen_test_vec_for_vdaf(
     agg_shares = []
     for j in range(vdaf.SHARES):
         out_shares_j = [out[j] for out in out_shares]
-        agg_share_j = vdaf.aggregate(agg_param, out_shares_j)
+        agg_share_j = vdaf.agg_init(agg_param)
+        for out_share in out_shares_j:
+            agg_share_j = vdaf.agg_update(agg_param, agg_share_j, out_share)
         agg_shares.append(agg_share_j)
         # REMOVE ME
         test_vec['agg_shares'].append(

--- a/poc/vdaf_poc/vdaf_prio3.py
+++ b/poc/vdaf_poc/vdaf_prio3.py
@@ -232,19 +232,28 @@ class Prio3(
             joint_rand_seed = self.joint_rand_seed(ctx, joint_rand_parts)
         return joint_rand_seed
 
-    # NOTE: This method is excerpted in the document, de-indented, as
-    # figure {{prio3-out2agg}}. Its width should be limited to 69 columns
-    # after de-indenting, or 73 columns before de-indenting, to avoid
-    # warnings from xml2rfc.
+    # NOTE: Methods `agg_init()`, `agg_update()`, and `merge()` are
+    # excerpted in the document, de-indented, as figure
+    # {{prio3-out2agg}}. The width should be limited to 69 columns after
+    # de-indenting, or 73 columns before de-indenting, to avoid warnings
+    # from xml2rfc.
     # ===================================================================
-    def aggregate(
-            self,
-            _agg_param: None,
-            out_shares: list[list[F]]) -> list[F]:
-        agg_share = self.flp.field.zeros(self.flp.OUTPUT_LEN)
-        for out_share in out_shares:
-            agg_share = vec_add(agg_share, out_share)
-        return agg_share
+    def agg_init(self, _agg_param: None) -> list[F]:
+        return self.flp.field.zeros(self.flp.OUTPUT_LEN)
+
+    def agg_update(self,
+                   _agg_param: None,
+                   agg_share: list[F],
+                   out_share: list[F]) -> list[F]:
+        return vec_add(agg_share, out_share)
+
+    def merge(self,
+              _agg_param: None,
+              agg_shares: list[list[F]]) -> list[F]:
+        agg = self.agg_init(None)
+        for agg_share in agg_shares:
+            agg = vec_add(agg, agg_share)
+        return agg
 
     # NOTE: This method is excerpted in the document, de-indented, as
     # figure {{prio3-agg-output}}. Its width should be limited to 69
@@ -256,9 +265,7 @@ class Prio3(
             _agg_param: None,
             agg_shares: list[list[F]],
             num_measurements: int) -> AggResult:
-        agg = self.flp.field.zeros(self.flp.OUTPUT_LEN)
-        for agg_share in agg_shares:
-            agg = vec_add(agg, agg_share)
+        agg = self.merge(None, agg_shares)
         return self.flp.decode(agg, num_measurements)
 
     # Auxiliary functions


### PR DESCRIPTION
Closes #432.

Modify both `Daf` and `Vdaf` by replacing `aggregate()` with two
methods:

* `agg_init()` returns an empty aggregate share
* `agg_update()` updates an aggregate share with an output share

Also, add a method `merge()` for merging two aggregate shares, as will be required for specifying aggregation in DAP.