### PR TITLE
Pass through errors in addition to warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,5 @@ jobs:
       run: "bash -c '! grep -r --file=rejected_dictionary draft-irtf-cfrg-vdaf.md poc'"
 
     - name: "Check for warnings emitted by xml2rfc"
-      run: "bash -c 'make |& (! grep Warning)'"
+      run: |
+        bash -c -o pipefail 'make |& (! grep -E "Warning|Error")'


### PR DESCRIPTION
This improves the new step in the "Lint document" job by failing on errors as well (via `-o pipefail`) and passing through error messages. This is largely handled by the "Update Editor's Copy" job, but it makes sense that this job should fail as well.

Testing:
- With a warning: https://github.com/cfrg/draft-irtf-cfrg-vdaf/actions/runs/11240619833/job/31250344834
- With an error: https://github.com/cfrg/draft-irtf-cfrg-vdaf/actions/runs/11240640344/job/31250406562