### PR TITLE
Add two more Poplar1 test vectors

### DIFF
--- a/poc/gen_test_vec.py
+++ b/poc/gen_test_vec.py
@@ -183,6 +183,7 @@ if __name__ == '__main__':
     )
 
     # Poplar1
+    poplar1_test_number = 0
     tests: list[tuple[int, tuple[tuple[bool, ...], ...]]] = [
         (0, ((False,), (True,))),
         (1, ((False, False), (False, True), (True, False), (True, True))),
@@ -216,8 +217,35 @@ if __name__ == '__main__':
             (test_level, prefixes),
             ctx,
             measurements,
-            test_level,
+            poplar1_test_number,
         )
+        poplar1_test_number += 1
+
+    tests = [
+        (0, ((False,), (True,))),
+        (10, (
+            (False,) * 11,
+            (True, True, False, False, True, False, False, False, False, False,
+             False),
+            (True, True, False, False, True, False, False, False, False, False,
+             True),
+            (True,) * 11,
+        )),
+    ]
+    measurements = [
+        (True, True, False, False, True, False, False, False, False, False,
+         True),
+    ]
+    for (test_level, prefixes) in tests:
+        gen_test_vec_for_vdaf(
+            vdaf_test_vec_path,
+            vdaf_poplar1.Poplar1(11),
+            (test_level, prefixes),
+            ctx,
+            measurements,
+            poplar1_test_number,
+        )
+        poplar1_test_number += 1
 
     # IdpfBBCGGI21
     gen_test_vec_for_idpf(

--- a/test_vec/vdaf/Poplar1_4.json
+++ b/test_vec/vdaf/Poplar1_4.json
@@ -1,0 +1,73 @@
+{
+    "agg_param": [
+        0,
+        [
+            [
+                false
+            ],
+            [
+                true
+            ]
+        ]
+    ],
+    "agg_result": [
+        0,
+        1
+    ],
+    "agg_shares": [
+        "f8145f10fdc8bca62df57afdc4066a8c",
+        "09eba0ef01374359d50a85023af99573"
+    ],
+    "bits": 11,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "prep": [
+        {
+            "input_shares": [
+                "000102030405060708090a0b0c0d0e0f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3fc2ae29156142560363d6b3101bbc3a3c831ab3334d5212f220f7be62a879dfe3303d99c9b91c2ec4b2be88bf152958538910d1b290d4132fef827a3497d8b6afd07a6d42b5dd7418fe90b98a2fe671e6b09afa685444f5765969e1a411c6180b72e62f67b7d8338edff68762d0d0a59baa4793638727a6162003f84c2596acb467c4e928d904546058cd260b0042b3bb0294e677645e2078d76c33ea1a53929de1aef060ec73d23fffc162594b5be6c43ca72c91cd9814b72ecd11894674a56fe8bd2713309a0b1f19794338f30477cc3e36e5d8c889529db1d245507bc99900",
+                "101112131415161718191a1b1c1d1e1f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f7f3c82bd56101979a4ab82454a0d0692cd62a7dc020b297feb9bc83164430e9d6db65e54d1f01d3102ffaa1e6542b45ab78ca492593b46e06e76d0d8d758ba8c3b15c2f12607b151228c095e1958aa23da07e702e6350ad9f4a63bfa33cfe2f7257bf42fd73f5fa2dc92a4988f14f40934886a69f8df372cebc3468df580d5c07e05112170e8d81b30e346eccec758a1061c0c7aa27020e5ffb2c3fb90d089144fdb1011273eecfa42ccca7e8b5af4c70f7cc82df8c8e0fc9a0cb8a10aa026736f3961d47e3f4a275c11311a7ef12849beb141a53a937378fa80413eda1e2f6f"
+            ],
+            "measurement": [
+                true,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true
+            ],
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [
+                [
+                    "f8145f10fdc8bca6",
+                    "2df57afdc4066a8c"
+                ],
+                [
+                    "09eba0ef01374359",
+                    "d50a85023af99573"
+                ]
+            ],
+            "prep_messages": [
+                "1be0415318fa71a0025509fdb4559fced849a418e0819d4c",
+                ""
+            ],
+            "prep_shares": [
+                [
+                    "0666e598602128e425ea5ac5440b241198c1253251d0773e",
+                    "167a5cbab6d849bcdd6aae37704a7bbd40887ee68eb1250e"
+                ],
+                [
+                    "4a5f1a8007a83201",
+                    "b7a0e57ff757cdfe"
+                ]
+            ],
+            "public_share": "6a1329706203dc060e8f96eea7a90a09011bf9d6ec84927d83a71ac6f1110e0d11e7dbec8d93e59d350995244ae87c17a5ce6cfaff8ce533763568b692904206d7e470ece45c4fda5556d5b5b62c3d7be2dd649830ea94d67042a055fc38b0d4c307aeccd53526cb04f05ac3237e54ab58554582c00c3837f9ea51cf494b9ef71d413dccde24f39378eee9347774958295313fda51d3b1be516df9084ee46cad89fe554246acfd40d4c424c8356132d053344e90979f92f30320c2bbb1743b1d4f3578f54a5a9b0b242bf1841d6b39f5e70e1a75963d080ed76a295e89489ff47eb83541a49c02299250357f3bd66755a20ff515520f0712a459a651881d31f6bc0f2838fa1094e019c0d0625982399d50d9332948f9b83c59a1d039e07f9a1766b56f5818a51ed19930e9db0426c0a047d74e962240b3e06100c502868e30d62d547aca59df848918ef02e02a8683ec541237ae33b2bbfe7de5eb4b01991c8c0866a4949009c100fac98f8956d9bc82ffbf7eba76a7774146d2018dd5b97f331ddf546dde718780bb97364b321f7f9d524d21",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Poplar1_5.json
+++ b/test_vec/vdaf/Poplar1_5.json
@@ -1,0 +1,125 @@
+{
+    "agg_param": [
+        10,
+        [
+            [
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            ],
+            [
+                true,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            ],
+            [
+                true,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true
+            ],
+            [
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            ]
+        ]
+    ],
+    "agg_result": [
+        0,
+        0,
+        1,
+        0
+    ],
+    "agg_shares": [
+        "d2cd4b7f24280e5a405b5b5cd4ae2d5190e6a18cd895929de2b7613739347f1f7ec642e913685f1b2be02add94a1000201bed9d86ed118f624d13423ce10ff0128a3d7193a01b7f10727e695de56ddb14df1cb8612697284bef73f0b8ad35b0cbce0dfca542e1e9a6b91f9db47d6bb68efcdafd7c0f58c76ab8f96ec77b03828",
+        "1b32b480dbd7f1a5bfa4a4a32b51d2ae6f195e73276a6d621d489ec8c6cb80606f39bd16ec97a0e4d41fd5226b5efffdfe412627912ee709db2ecbdc31ef007ec65c28e6c5fe480ef8d8196a21a9224eb20e3479ed968d7b4108c0f4752ca473311f2035abd1e165946e0624b8294497103250283f0a738954706913884fc757"
+    ],
+    "bits": 11,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "prep": [
+        {
+            "input_shares": [
+                "000102030405060708090a0b0c0d0e0f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3fc2ae29156142560363d6b3101bbc3a3c831ab3334d5212f220f7be62a879dfe3303d99c9b91c2ec4b2be88bf152958538910d1b290d4132fef827a3497d8b6afd07a6d42b5dd7418fe90b98a2fe671e6b09afa685444f5765969e1a411c6180b72e62f67b7d8338edff68762d0d0a59baa4793638727a6162003f84c2596acb467c4e928d904546058cd260b0042b3bb0294e677645e2078d76c33ea1a53929de1aef060ec73d23fffc162594b5be6c43ca72c91cd9814b72ecd11894674a56fe8bd2713309a0b1f19794338f30477cc3e36e5d8c889529db1d245507bc99900",
+                "101112131415161718191a1b1c1d1e1f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f7f3c82bd56101979a4ab82454a0d0692cd62a7dc020b297feb9bc83164430e9d6db65e54d1f01d3102ffaa1e6542b45ab78ca492593b46e06e76d0d8d758ba8c3b15c2f12607b151228c095e1958aa23da07e702e6350ad9f4a63bfa33cfe2f7257bf42fd73f5fa2dc92a4988f14f40934886a69f8df372cebc3468df580d5c07e05112170e8d81b30e346eccec758a1061c0c7aa27020e5ffb2c3fb90d089144fdb1011273eecfa42ccca7e8b5af4c70f7cc82df8c8e0fc9a0cb8a10aa026736f3961d47e3f4a275c11311a7ef12849beb141a53a937378fa80413eda1e2f6f"
+            ],
+            "measurement": [
+                true,
+                true,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true
+            ],
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [
+                [
+                    "d2cd4b7f24280e5a405b5b5cd4ae2d5190e6a18cd895929de2b7613739347f1f",
+                    "7ec642e913685f1b2be02add94a1000201bed9d86ed118f624d13423ce10ff01",
+                    "28a3d7193a01b7f10727e695de56ddb14df1cb8612697284bef73f0b8ad35b0c",
+                    "bce0dfca542e1e9a6b91f9db47d6bb68efcdafd7c0f58c76ab8f96ec77b03828"
+                ],
+                [
+                    "1b32b480dbd7f1a5bfa4a4a32b51d2ae6f195e73276a6d621d489ec8c6cb8060",
+                    "6f39bd16ec97a0e4d41fd5226b5efffdfe412627912ee709db2ecbdc31ef007e",
+                    "c65c28e6c5fe480ef8d8196a21a9224eb20e3479ed968d7b4108c0f4752ca473",
+                    "311f2035abd1e165946e0624b8294497103250283f0a738954706913884fc757"
+                ]
+            ],
+            "prep_messages": [
+                "d3c3fc12914cd2a31c7a41b62a77273b5275154cdb30a0fec68912f9ccc66b0b6b15ce285c181e4f16a65fbcc188b3f1d4daaa14b6823f69127b41ec7e1f30516ff551aea1448229641258ba9b3fb64b4b8b4b166010c803d107541d5045425e",
+                ""
+            ],
+            "prep_shares": [
+                [
+                    "d4c8460a5f62404f0ab779db098a078a8643f294f2ead87fef399a85adca9b2447ea034a67ec05dca8afc0a41c9ebc8e445ff7aca391a80e6ba24be308435f65daca191dddf03952c12402cc424509236c429d30c430944e8ad88424e35ddb0c",
+                    "ecfab50832ea915412c3c7da20ed1fb1cb3123b7e845c77ed74f78731ffccf66112bcadef42b18736df69e17a5eaf662907bb36712f1965aa7d8f50876dcd06b952a3891c45348d7a2ed55ee58faac28df48aee59bdf33b5462fcff86ce76651"
+                ],
+                [
+                    "1a4aa3de4303c3d7d525a4c391558ea83bd9eec7db79e19415795cbb718eb571",
+                    "d3b55c21bcfc3c282ada5b3c6eaa7157c426113824861e6bea86a3448e714a0e"
+                ]
+            ],
+            "public_share": "6a1329706203dc060e8f96eea7a90a09011bf9d6ec84927d83a71ac6f1110e0d11e7dbec8d93e59d350995244ae87c17a5ce6cfaff8ce533763568b692904206d7e470ece45c4fda5556d5b5b62c3d7be2dd649830ea94d67042a055fc38b0d4c307aeccd53526cb04f05ac3237e54ab58554582c00c3837f9ea51cf494b9ef71d413dccde24f39378eee9347774958295313fda51d3b1be516df9084ee46cad89fe554246acfd40d4c424c8356132d053344e90979f92f30320c2bbb1743b1d4f3578f54a5a9b0b242bf1841d6b39f5e70e1a75963d080ed76a295e89489ff47eb83541a49c02299250357f3bd66755a20ff515520f0712a459a651881d31f6bc0f2838fa1094e019c0d0625982399d50d9332948f9b83c59a1d039e07f9a1766b56f5818a51ed19930e9db0426c0a047d74e962240b3e06100c502868e30d62d547aca59df848918ef02e02a8683ec541237ae33b2bbfe7de5eb4b01991c8c0866a4949009c100fac98f8956d9bc82ffbf7eba76a7774146d2018dd5b97f331ddf546dde718780bb97364b321f7f9d524d21",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}


### PR DESCRIPTION
This adds two additional Poplar1 test vectors, with `BITS=11`. One evaluates the first level, and the other evaluates the last level. This addition will flush out possible issues with byte order in the IDPF public share's control bit correction words. (the existing test vectors are all for `BITS=4`)