### PR TITLE
Prio3, Poplar1: Set `xof` to `XofTurboShake128`

### DIFF
--- a/poc/vdaf_poc/xof.py
+++ b/poc/vdaf_poc/xof.py
@@ -61,7 +61,7 @@ class Xof(metaclass=ABCMeta):
 
         Pre-conditions:
 
-            - `len(seed) == Xof.SEED_SIZE`
+            - `len(seed) == cls.SEED_SIZE`
         """
         xof = cls(seed, dst, binder)
         return xof.next(cls.SEED_SIZE)
@@ -97,7 +97,7 @@ class Xof(metaclass=ABCMeta):
         Pre-conditions:
 
             - `field` is sub-class of `Field`
-            - `len(seed) == Xof.SEED_SIZE`
+            - `len(seed) == cls.SEED_SIZE`
             - `length > 0`
         """
         xof = cls(seed, dst, binder)


### PR DESCRIPTION
Stacked on #475.

Previously we imagined making this generic in case we wanted to define variants with different XOFs. We don't have nay in this document, so fix XofTurboShake128 as the XOF as early as possible.

While at it, don't overload `Xof` in parameter tables, as this is now just an abstract base class. Likewise for `Idpf` and `Flp`.