### PR TITLE
Pass of preliminaries

### DIFF
--- a/poc/vdaf_poc/common.py
+++ b/poc/vdaf_poc/common.py
@@ -146,7 +146,7 @@ def format_dst(algo_class: int,
                algo: int,
                usage: int) -> bytes:
     """
-    Format XOF domain separation tag for use within a (V)DAF.
+    Format XOF domain separation tag.
 
     Pre-conditions:
 

--- a/poc/vdaf_poc/field.py
+++ b/poc/vdaf_poc/field.py
@@ -3,7 +3,7 @@
 import random
 from typing import Self, TypeVar, cast
 
-from vdaf_poc.common import from_le_bytes, to_le_bytes
+from vdaf_poc.common import from_le_bytes, front, to_le_bytes
 
 
 class Field:
@@ -54,15 +54,14 @@ class Field:
         """
         Parse a vector of field elements from `encoded`.
         """
-        L = cls.ENCODED_SIZE
-        if len(encoded) % L != 0:
+        if len(encoded) % cls.ENCODED_SIZE != 0:
             raise ValueError(
                 'input length must be a multiple of the size of an '
                 'encoded field element')
 
         vec = []
-        for i in range(0, len(encoded), L):
-            encoded_x = encoded[i:i+L]
+        while len(encoded) > 0:
+            (encoded_x, encoded) = front(cls.ENCODED_SIZE, encoded)
             x = from_le_bytes(encoded_x)
             if x >= cls.MODULUS:
                 raise ValueError('modulus overflow')

--- a/poc/vdaf_poc/xof.py
+++ b/poc/vdaf_poc/xof.py
@@ -239,7 +239,7 @@ class XofFixedKeyAes128(Xof):
         key that stays constant for all XOF evaluations of the same
         Client, but differs between Clients.
 
-        Function `AES128(key, block)` is the AES-128 blockcipher.
+        Function `AES128(key, block)` is the AES128 blockcipher.
 
         ---
 


### PR DESCRIPTION
Stacked on #483.

* Note that `Field.rand_vec()` is not used in the spec of any VDAF. (It's only used for `run_flp()`.)

* Specify notation of arithmetic operations on fields.

* Use `front()` in field element decoding, which is more in line with how we write down decoding algorithms in other parts of the draft.

* Say what we mean by "order" of the multiplicative subgroup of NTT fields

* XofTurboShake128: Set stricter bounds on the inputs (how big can the seed be)

* XofFixedKeyAes128: Set bounds on the length of the domain separation tag.

* Clarify the motivation for XofFixedKeyAes128.

* Write "AES128" instead of "AES-128" as this is how we denote the function in the spec.