### PR TITLE
Clean up after full pass

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1979,7 +1979,7 @@ are used to encode measurements in some variants of Prio3
 ({{prio3-instantiations}}).
 
 ~~~ python
-def encode_into_vit_vec(
+def encode_into_bit_vec(
         cls,
         val: int,
         bits: int) -> list[Self]:
@@ -2002,7 +2002,7 @@ def encode_into_vit_vec(
         encoded.append(cls((val >> l) & 1))
     return encoded
 
-def decode_from_vit_vec(cls, vec: list[Self]) -> Self:
+def decode_from_bit_vec(cls, vec: list[Self]) -> Self:
     """
     Decode the field element from the bit representation, expressed
     as a vector of field elements `vec`.
@@ -3865,25 +3865,25 @@ class Sum(Valid[int, int, F]):
             out.append(self.GADGETS[0].eval(self.field, [b]))
 
         range_check = self.offset * shares_inv + \
-            self.field.decode_from_vit_vec(meas[:self.bits]) - \
-            self.field.decode_from_vit_vec(meas[self.bits:])
+            self.field.decode_from_bit_vec(meas[:self.bits]) - \
+            self.field.decode_from_bit_vec(meas[self.bits:])
         out.append(range_check)
         return out
 
     def encode(self, measurement: int) -> list[F]:
         encoded = []
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             measurement,
             self.bits
         )
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             measurement + self.offset.int(),
             self.bits
         )
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
-        return [self.field.decode_from_vit_vec(meas[:self.bits])]
+        return [self.field.decode_from_bit_vec(meas[:self.bits])]
 
     def decode(self, output: list[F], _num_measurements: int) -> int:
         return output[0].int()
@@ -3999,14 +3999,14 @@ class SumVec(Valid[list[int], list[int], F]):
     def encode(self, measurement: list[int]) -> list[F]:
         encoded = []
         for val in measurement:
-            encoded += self.field.encode_into_vit_vec(
+            encoded += self.field.encode_into_bit_vec(
                 val, self.bits)
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
         truncated = []
         for i in range(self.length):
-            truncated.append(self.field.decode_from_vit_vec(
+            truncated.append(self.field.decode_from_bit_vec(
                 meas[i * self.bits: (i + 1) * self.bits]
             ))
         return truncated
@@ -4275,7 +4275,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
         count_vec = meas[:self.length]
         weight = sum(count_vec, self.field(0))
         weight_reported = \
-            self.field.decode_from_vit_vec(meas[self.length:])
+            self.field.decode_from_bit_vec(meas[self.length:])
         weight_check = self.offset*shares_inv + weight - \
             weight_reported
 
@@ -4293,7 +4293,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
 
         encoded = []
         encoded += count_vec
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             (self.offset + weight_reported).int(),
             self.bits_for_weight)
         return encoded

--- a/poc/tests/test_field.py
+++ b/poc/tests/test_field.py
@@ -38,8 +38,8 @@ class TestFields(unittest.TestCase):
         vals = [i for i in range(15)]
         bits = 4
         for val in vals:
-            encoded = cls.encode_into_bit_vector(val, bits)
-            self.assertTrue(cls.decode_from_bit_vector(
+            encoded = cls.encode_into_vit_vec(val, bits)
+            self.assertTrue(cls.decode_from_vit_vec(
                 encoded).int() == val)
 
     def run_ntt_field_test(self, cls: type[NttField]) -> None:

--- a/poc/tests/test_field.py
+++ b/poc/tests/test_field.py
@@ -38,8 +38,8 @@ class TestFields(unittest.TestCase):
         vals = [i for i in range(15)]
         bits = 4
         for val in vals:
-            encoded = cls.encode_into_vit_vec(val, bits)
-            self.assertTrue(cls.decode_from_vit_vec(
+            encoded = cls.encode_into_bit_vec(val, bits)
+            self.assertTrue(cls.decode_from_bit_vec(
                 encoded).int() == val)
 
     def run_ntt_field_test(self, cls: type[NttField]) -> None:

--- a/poc/vdaf_poc/daf.py
+++ b/poc/vdaf_poc/daf.py
@@ -168,12 +168,10 @@ def run_daf(
 
     Pre-conditions:
 
-        - `type(agg_param) == daf.AggParam`
-        - `type(measurement) == daf.Measurement` for each
-          `measurement` in `measurements`
-        - `len(nonce) == daf.NONCE_SIZE` for each `nonce` in `nonces`
         - `len(nonces) == len(measurements)`
+        - `all(len(nonce) == daf.NONCE_SIZE for nonce in nonces)`
     """
+    # REMOVE ME
     if any(len(nonce) != daf.NONCE_SIZE for nonce in nonces):
         raise ValueError("incorrect nonce size")
     if len(nonces) != len(measurements):
@@ -185,14 +183,12 @@ def run_daf(
     agg_shares = [daf.agg_init(agg_param)
                   for _ in range(daf.SHARES)]
     for (measurement, nonce) in zip(measurements, nonces):
-        # Each Client shards its measurement into input shares and
-        # distributes them among the Aggregators.
+        # Sharding
         rand = gen_rand(daf.RAND_SIZE)
         (public_share, input_shares) = \
             daf.shard(ctx, measurement, nonce, rand)
 
-        # Each Aggregator computes its output share from its input
-        # share and aggregates it.
+        # Preparation, aggregation
         for j in range(daf.SHARES):
             out_share = daf.prep(ctx, j, agg_param, nonce,
                                  public_share, input_shares[j])
@@ -200,7 +196,7 @@ def run_daf(
                                            agg_shares[j],
                                            out_share)
 
-    # Collector unshards the aggregate result.
+    # Unsharding
     num_measurements = len(measurements)
     agg_result = daf.unshard(agg_param, agg_shares,
                              num_measurements)

--- a/poc/vdaf_poc/field.py
+++ b/poc/vdaf_poc/field.py
@@ -68,14 +68,14 @@ class Field:
             vec.append(cls(x))
         return vec
 
-    # NOTE: The encode_into_bit_vector() and decode_from_bit_vector()
+    # NOTE: The encode_into_vit_vec() and decode_from_vit_vec()
     # methods are excerpted in the document, de-indented, as the figure
     # {{field-bit-rep}}. Their width should be limited to 69 columns
     # after de-indenting, or 73 columns before de-indenting, to avoid
     # warnings from xml2rfc.
     # ===================================================================
     @classmethod
-    def encode_into_bit_vector(
+    def encode_into_vit_vec(
             cls,
             val: int,
             bits: int) -> list[Self]:
@@ -99,7 +99,7 @@ class Field:
         return encoded
 
     @classmethod
-    def decode_from_bit_vector(cls, vec: list[Self]) -> Self:
+    def decode_from_vit_vec(cls, vec: list[Self]) -> Self:
         """
         Decode the field element from the bit representation, expressed
         as a vector of field elements `vec`.

--- a/poc/vdaf_poc/field.py
+++ b/poc/vdaf_poc/field.py
@@ -68,14 +68,14 @@ class Field:
             vec.append(cls(x))
         return vec
 
-    # NOTE: The encode_into_vit_vec() and decode_from_vit_vec()
+    # NOTE: The encode_into_bit_vec() and decode_from_bit_vec()
     # methods are excerpted in the document, de-indented, as the figure
     # {{field-bit-rep}}. Their width should be limited to 69 columns
     # after de-indenting, or 73 columns before de-indenting, to avoid
     # warnings from xml2rfc.
     # ===================================================================
     @classmethod
-    def encode_into_vit_vec(
+    def encode_into_bit_vec(
             cls,
             val: int,
             bits: int) -> list[Self]:
@@ -99,7 +99,7 @@ class Field:
         return encoded
 
     @classmethod
-    def decode_from_vit_vec(cls, vec: list[Self]) -> Self:
+    def decode_from_bit_vec(cls, vec: list[Self]) -> Self:
         """
         Decode the field element from the bit representation, expressed
         as a vector of field elements `vec`.

--- a/poc/vdaf_poc/flp_bbcggi19.py
+++ b/poc/vdaf_poc/flp_bbcggi19.py
@@ -855,7 +855,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
         count_vec = meas[:self.length]
         weight = sum(count_vec, self.field(0))
         weight_reported = \
-            self.field.decode_from_bit_vector(meas[self.length:])
+            self.field.decode_from_vit_vec(meas[self.length:])
         weight_check = self.offset*shares_inv + weight - \
             weight_reported
 
@@ -873,7 +873,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
 
         encoded = []
         encoded += count_vec
-        encoded += self.field.encode_into_bit_vector(
+        encoded += self.field.encode_into_vit_vec(
             (self.offset + weight_reported).int(),
             self.bits_for_weight)
         return encoded
@@ -982,14 +982,14 @@ class SumVec(Valid[list[int], list[int], F]):
                     'entry of measurement vector is out of range'
                 )
 
-            encoded += self.field.encode_into_bit_vector(
+            encoded += self.field.encode_into_vit_vec(
                 val, self.bits)
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
         truncated = []
         for i in range(self.length):
-            truncated.append(self.field.decode_from_bit_vector(
+            truncated.append(self.field.decode_from_vit_vec(
                 meas[i * self.bits: (i + 1) * self.bits]
             ))
         return truncated
@@ -1070,25 +1070,25 @@ class Sum(Valid[int, int, F]):
             out.append(self.GADGETS[0].eval(self.field, [b]))
 
         range_check = self.offset * shares_inv + \
-            self.field.decode_from_bit_vector(meas[:self.bits]) - \
-            self.field.decode_from_bit_vector(meas[self.bits:])
+            self.field.decode_from_vit_vec(meas[:self.bits]) - \
+            self.field.decode_from_vit_vec(meas[self.bits:])
         out.append(range_check)
         return out
 
     def encode(self, measurement: int) -> list[F]:
         encoded = []
-        encoded += self.field.encode_into_bit_vector(
+        encoded += self.field.encode_into_vit_vec(
             measurement,
             self.bits
         )
-        encoded += self.field.encode_into_bit_vector(
+        encoded += self.field.encode_into_vit_vec(
             measurement + self.offset.int(),
             self.bits
         )
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
-        return [self.field.decode_from_bit_vector(meas[:self.bits])]
+        return [self.field.decode_from_vit_vec(meas[:self.bits])]
 
     def decode(self, output: list[F], _num_measurements: int) -> int:
         return output[0].int()

--- a/poc/vdaf_poc/flp_bbcggi19.py
+++ b/poc/vdaf_poc/flp_bbcggi19.py
@@ -855,7 +855,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
         count_vec = meas[:self.length]
         weight = sum(count_vec, self.field(0))
         weight_reported = \
-            self.field.decode_from_vit_vec(meas[self.length:])
+            self.field.decode_from_bit_vec(meas[self.length:])
         weight_check = self.offset*shares_inv + weight - \
             weight_reported
 
@@ -873,7 +873,7 @@ class MultihotCountVec(Valid[list[int], list[int], F]):
 
         encoded = []
         encoded += count_vec
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             (self.offset + weight_reported).int(),
             self.bits_for_weight)
         return encoded
@@ -982,14 +982,14 @@ class SumVec(Valid[list[int], list[int], F]):
                     'entry of measurement vector is out of range'
                 )
 
-            encoded += self.field.encode_into_vit_vec(
+            encoded += self.field.encode_into_bit_vec(
                 val, self.bits)
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
         truncated = []
         for i in range(self.length):
-            truncated.append(self.field.decode_from_vit_vec(
+            truncated.append(self.field.decode_from_bit_vec(
                 meas[i * self.bits: (i + 1) * self.bits]
             ))
         return truncated
@@ -1070,25 +1070,25 @@ class Sum(Valid[int, int, F]):
             out.append(self.GADGETS[0].eval(self.field, [b]))
 
         range_check = self.offset * shares_inv + \
-            self.field.decode_from_vit_vec(meas[:self.bits]) - \
-            self.field.decode_from_vit_vec(meas[self.bits:])
+            self.field.decode_from_bit_vec(meas[:self.bits]) - \
+            self.field.decode_from_bit_vec(meas[self.bits:])
         out.append(range_check)
         return out
 
     def encode(self, measurement: int) -> list[F]:
         encoded = []
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             measurement,
             self.bits
         )
-        encoded += self.field.encode_into_vit_vec(
+        encoded += self.field.encode_into_bit_vec(
             measurement + self.offset.int(),
             self.bits
         )
         return encoded
 
     def truncate(self, meas: list[F]) -> list[F]:
-        return [self.field.decode_from_vit_vec(meas[:self.bits])]
+        return [self.field.decode_from_bit_vec(meas[:self.bits])]
 
     def decode(self, output: list[F], _num_measurements: int) -> int:
         return output[0].int()

--- a/poc/vdaf_poc/vdaf.py
+++ b/poc/vdaf_poc/vdaf.py
@@ -265,7 +265,7 @@ def run_vdaf(
         - `len(nonces) == len(measurements)`
         - `all(len(nonce) == vdaf.NONCE_SIZE for nonce in nonces)`
     """
-
+    # REMOVE ME
     if len(verify_key) != vdaf.VERIFY_KEY_SIZE:
         raise ValueError("incorrect verify_key size")
     if any(len(nonce) != vdaf.NONCE_SIZE for nonce in nonces):
@@ -280,12 +280,12 @@ def run_vdaf(
     for (nonce, measurement) in zip(nonces, measurements):
         assert len(nonce) == vdaf.NONCE_SIZE
 
-        # Each Client shards its measurement into input shares.
+        # Sharding
         rand = gen_rand(vdaf.RAND_SIZE)
         (public_share, input_shares) = \
             vdaf.shard(ctx, measurement, nonce, rand)
 
-        # Each Aggregator initializes its preparation state.
+        # Initialize preparation
         prep_states = []
         outbound_prep_shares = []
         for j in range(vdaf.SHARES):
@@ -297,7 +297,7 @@ def run_vdaf(
             prep_states.append(state)
             outbound_prep_shares.append(share)
 
-        # Aggregators complete preparation.
+        # Complete preparation
         for i in range(vdaf.ROUNDS - 1):
             prep_msg = vdaf.prep_shares_to_prep(ctx,
                                                 agg_param,
@@ -314,7 +314,7 @@ def run_vdaf(
                                             agg_param,
                                             outbound_prep_shares)
 
-        # Each Aggregator computes and aggregates its output share.
+        # Aggregation
         for j in range(vdaf.SHARES):
             out_share = vdaf.prep_next(ctx, prep_states[j], prep_msg)
             assert not isinstance(out_share, tuple)
@@ -322,7 +322,7 @@ def run_vdaf(
                                             agg_shares[j],
                                             out_share)
 
-    # Collector unshards the aggregate.
+    # Unsharding
     num_measurements = len(measurements)
     agg_result = vdaf.unshard(agg_param, agg_shares,
                               num_measurements)

--- a/poc/vdaf_poc/vdaf_prio3.py
+++ b/poc/vdaf_poc/vdaf_prio3.py
@@ -124,7 +124,7 @@ class Prio3(
             previous_agg_params: list[None]) -> bool:
         return len(previous_agg_params) == 0
 
-    # NOTE: The prep_init(), prep_next(), and prep_shares_to_prep()
+    # NOTE: The prep_init(), prep_shares_to_prep(), and prep_next()
     # methods are excerpted in the document, de-indented, as figure
     # {{prio3-prep-state}}. Their width should be limited to 69 columns
     # after de-indenting, or 73 columns before de-indenting, to avoid
@@ -183,22 +183,6 @@ class Prio3(
         prep_share = (verifiers_share, joint_rand_part)
         return (prep_state, prep_share)
 
-    def prep_next(
-        self,
-        _ctx: bytes,
-        prep_state: Prio3PrepState[F],
-        prep_msg: Optional[bytes]
-    ) -> tuple[Prio3PrepState[F], Prio3PrepShare[F]] | list[F]:
-        joint_rand_seed = prep_msg
-        (out_share, corrected_joint_rand_seed) = prep_state
-
-        # If joint randomness was used, check that the value computed by
-        # the Aggregators matches the value indicated by the Client.
-        if joint_rand_seed != corrected_joint_rand_seed:
-            raise ValueError('joint randomness check failed')
-
-        return out_share
-
     def prep_shares_to_prep(
             self,
             ctx: bytes,
@@ -227,6 +211,22 @@ class Prio3(
         if self.flp.JOINT_RAND_LEN > 0:
             joint_rand_seed = self.joint_rand_seed(ctx, joint_rand_parts)
         return joint_rand_seed
+
+    def prep_next(
+        self,
+        _ctx: bytes,
+        prep_state: Prio3PrepState[F],
+        prep_msg: Optional[bytes]
+    ) -> tuple[Prio3PrepState[F], Prio3PrepShare[F]] | list[F]:
+        joint_rand_seed = prep_msg
+        (out_share, corrected_joint_rand_seed) = prep_state
+
+        # If joint randomness was used, check that the value computed by
+        # the Aggregators matches the value indicated by the Client.
+        if joint_rand_seed != corrected_joint_rand_seed:
+            raise ValueError('joint randomness check failed')
+
+        return out_share
 
     # NOTE: Methods `agg_init()`, `agg_update()`, and `merge()` are
     # excerpted in the document, de-indented, as figure


### PR DESCRIPTION
Stacked on #498.

Miscellaneous improvements:

* Add an illustration of DAF preparation

* Clean up bounds on `run_daf()` and `run_vdaf()`

    * Document only the pre-conditions that are relevant
    * Remove code for enforcing the pre-conditions
    * Use comments only for the stages of execution: sharding, preparation, etc.

* Punt VDAF prep state listing to appendix

* Rename `encode_to_bit_vector()` to `encode_to_bit_vec()` for consistency with abbreviation of "vector" to "vec" in other functions

* In titles, rename "Construction" to "Specification"

* In Prio3, list `prep_shares_to_prep()` before `prep_next()` so that the computations are listed in chronological order. (We could do the same for Poplar1, but there it's less helpful because we end up calling `prep_next()` twice.)