### PR TITLE
Poplar1: Move prefix order check to is_valid()

### DIFF
--- a/poc/tests/test_vdaf_poplar1.py
+++ b/poc/tests/test_vdaf_poplar1.py
@@ -220,9 +220,24 @@ class TestPoplar1(TestVdaf):
         ]
         self.assertFalse(cls.is_valid(agg_params[1], list(agg_params[:1])))
 
-        # Test `is_valid` rejects unsorted prefixes.
+        # Test `is_valid` rejects unsorted and duplicate prefixes.
         agg_params = [
             (0, (int_to_bit_string(0b1, 1), int_to_bit_string(0b0, 1))),
+        ]
+        self.assertFalse(cls.is_valid(agg_params[0], list(agg_params)))
+        agg_params = [
+            (2, (
+                int_to_bit_string(0b100, 3),
+                int_to_bit_string(0b011, 3),
+            )),
+        ]
+        self.assertFalse(cls.is_valid(agg_params[0], list(agg_params)))
+        agg_params = [
+            (2, (
+                int_to_bit_string(0b000, 3),
+                int_to_bit_string(0b010, 3),
+                int_to_bit_string(0b010, 3),
+            )),
         ]
         self.assertFalse(cls.is_valid(agg_params[0], list(agg_params)))
 

--- a/poc/tests/test_vdaf_poplar1.py
+++ b/poc/tests/test_vdaf_poplar1.py
@@ -220,6 +220,12 @@ class TestPoplar1(TestVdaf):
         ]
         self.assertFalse(cls.is_valid(agg_params[1], list(agg_params[:1])))
 
+        # Test `is_valid` rejects unsorted prefixes.
+        agg_params = [
+            (0, (int_to_bit_string(0b1, 1), int_to_bit_string(0b0, 1))),
+        ]
+        self.assertFalse(cls.is_valid(agg_params[0], list(agg_params)))
+
     def test_aggregation_parameter_encoding(self) -> None:
         # Test aggregation parameter encoding.
         cls = Poplar1(256)

--- a/poc/vdaf_poc/vdaf_poplar1.py
+++ b/poc/vdaf_poc/vdaf_poplar1.py
@@ -196,14 +196,22 @@ class Poplar1(
             agg_param: Poplar1AggParam,
             previous_agg_params: list[Poplar1AggParam]) -> bool:
         """
-        Checks that levels are increasing between calls, and also
+        Checks that candidate prefixes are unique and lexicographically
+        sorted, checks that levels are increasing between calls, and also
         enforces that the prefixes at each level are suffixes of the
         previous level's prefixes.
         """
+        (level, prefixes) = agg_param
+
+        # Ensure that candidate prefixes are all unique and appear in
+        # lexicographic order.
+        for i in range(1, len(prefixes)):
+            if prefixes[i - 1] >= prefixes[i]:
+                return False
+
         if len(previous_agg_params) < 1:
             return True
 
-        (level, prefixes) = agg_param
         (last_level, last_prefixes) = previous_agg_params[-1]
         last_prefixes_set = set(last_prefixes)
 
@@ -239,12 +247,6 @@ class Poplar1(
         (level, prefixes) = agg_param
         (key, corr_seed, corr_inner, corr_leaf) = input_share
         field = self.idpf.current_field(level)
-
-        # Ensure that candidate prefixes are all unique and appear in
-        # lexicographic order.
-        for i in range(1, len(prefixes)):
-            if prefixes[i - 1] >= prefixes[i]:
-                raise ValueError('out of order prefix')
 
         # Evaluate the IDPF key at the given set of prefixes.
         value = self.idpf.eval(


### PR DESCRIPTION
Closes #494.