### PR TITLE
Silence SVG warning via front matter

### DIFF
--- a/.github/workflows/make-with-lints.sh
+++ b/.github/workflows/make-with-lints.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-make |& \
-	grep -v 'Warning: Found SVG with width or height specified, which will make the artwork not scale.  Specify a viewBox only to let the artwork scale.' | \
-	(! grep -E "Warning|Error")
+make |& (! grep -E "Warning|Error")

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -255,6 +255,10 @@ informative:
     refcontent: "commit hash c0e76dc"
     date: December 2024
 
+v3xml2rfc:
+  silence:
+  - Found SVG with width or height specified
+
 --- abstract
 
 This document describes Verifiable Distributed Aggregation Functions (VDAFs), a


### PR DESCRIPTION
This adds some configuration to the front matter to silence the SVG warning we're getting, and cleans up the shell script we were using to filter these out previously. See https://mailarchive.ietf.org/arch/msg/rfc-markdown/reUEfraLI_-XH7fO0wKe2ErFxno/.

This works locally, but I think we'll need to wait for a new Docker image to be built that includes kramdown-rfc 1.7.22 before it'll work in CI.