### PR TITLE
Negative test vectors

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -2936,6 +2936,7 @@ def prep_init(
         assert joint_rand_parts is not None
         joint_rand_part = self.joint_rand_part(
             ctx, agg_id, blind, meas_share, nonce)
+        joint_rand_parts = list(joint_rand_parts)
         joint_rand_parts[agg_id] = joint_rand_part
         corrected_joint_rand_seed = self.joint_rand_seed(
             ctx, joint_rand_parts)

--- a/poc/gen_test_vec.py
+++ b/poc/gen_test_vec.py
@@ -2,11 +2,17 @@
 
 import json
 import os
+from typing import Any, cast
 
 from vdaf_poc.common import print_wrapped_line
 from vdaf_poc.field import Field64, Field128
-from vdaf_poc.idpf import Idpf
-from vdaf_poc.test_utils import gen_test_vec_for_vdaf, test_vec_gen_rand
+from vdaf_poc.idpf import FieldVec, Idpf
+from vdaf_poc.test_utils import (VdafTestVectorDict, gen_test_vec_for_vdaf,
+                                 pretty_print_vdaf_test_vec, test_vec_gen_rand,
+                                 write_test_vec)
+from vdaf_poc.vdaf_poplar1 import Poplar1, Poplar1InputShare
+from vdaf_poc.vdaf_prio3 import (Prio3, Prio3Count, Prio3Histogram,
+                                 Prio3InputShare)
 from vdaf_poc.xof import Xof
 
 # The path where test vectors are generated.
@@ -94,6 +100,421 @@ def gen_test_vec_for_xof(cls: type[Xof]) -> None:
             TEST_VECTOR_PATH, cls.__name__), 'w') as f:
         json.dump(test_vector, f, indent=4, sort_keys=True)
         f.write('\n')
+
+
+def gen_prio3_negative_test_vec(test_vec_path: str) -> None:
+    "Generates various negative test vectors for Prio3"
+
+    prio3count = Prio3Count(2)
+    nonce = test_vec_gen_rand(prio3count.NONCE_SIZE)
+    rand = test_vec_gen_rand(prio3count.RAND_SIZE)
+    public_share, [input_share_0, input_share_1] = prio3count.shard(
+        ctx,
+        True,
+        nonce,
+        rand,
+    )
+    verify_key = test_vec_gen_rand(prio3count.VERIFY_KEY_SIZE)
+
+    # Modify measurement share of leader input share.
+    bad_input_share_0_temp: list[Any] = list(
+        cast(tuple[Any, ...], input_share_0))
+    modified_measurement_share = list(
+        cast(list[Field64], bad_input_share_0_temp[0]))
+    modified_measurement_share[0] += Field64(1)
+    bad_input_share_0_temp[0] = modified_measurement_share
+    bad_input_share_0: tuple[list[Field64], list[Field64], None] = tuple(
+        bad_input_share_0_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3count,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        bad_input_share_0,
+        input_share_1,
+        test_vec_path,
+        "bad_meas_share",
+    )
+
+    # Modify a wire seed in the proof share of the leader input share.
+    bad_input_share_0_temp = list(cast(tuple[Any, ...], input_share_0))
+    modified_proof_share = list(
+        cast(list[Field64], bad_input_share_0_temp[1]))
+    modified_proof_share[0] += Field64(1)
+    bad_input_share_0_temp[1] = modified_proof_share
+    bad_input_share_0 = tuple(bad_input_share_0_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3count,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        bad_input_share_0,
+        input_share_1,
+        test_vec_path,
+        "bad_wire_seed",
+    )
+
+    # Modify the gadget polynomial in the proof share of the leader input
+    # share.
+    bad_input_share_0_temp = list(cast(tuple[Any, ...], input_share_0))
+    modified_proof_share = list(
+        cast(list[Field64], bad_input_share_0_temp[1]))
+    modified_proof_share[-1] += Field64(1)
+    bad_input_share_0_temp[1] = modified_proof_share
+    bad_input_share_0 = tuple(bad_input_share_0_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3count,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        bad_input_share_0,
+        input_share_1,
+        test_vec_path,
+        "bad_gadget_poly",
+    )
+
+    # Modify seed in helper input share.
+    bad_input_share_1_temp = list(cast(tuple[Any, ...], input_share_1))
+    modified_helper_seed = bytearray(bad_input_share_1_temp[0])
+    modified_helper_seed[0] ^= 1
+    bad_input_share_1_temp[0] = modified_helper_seed
+    bad_input_share_1 = tuple(bad_input_share_1_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3count,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        input_share_0,
+        bad_input_share_1,
+        test_vec_path,
+        "bad_helper_seed",
+    )
+
+    prio3histogram = Prio3Histogram(2, 5, 2)
+    rand = test_vec_gen_rand(prio3histogram.RAND_SIZE)
+    public_share, [input_share_0, input_share_1] = prio3histogram.shard(
+        ctx,
+        3,
+        nonce,
+        rand,
+    )
+
+    # Modify leader joint randomness blind.
+    bad_input_share_0_temp = list(cast(tuple[Any, ...], input_share_0))
+    modified_leader_blind = bytearray(bad_input_share_0_temp[2])
+    modified_leader_blind[0] ^= 1
+    bad_input_share_0_temp[2] = modified_leader_blind
+    bad_input_share_0 = tuple(bad_input_share_0_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3histogram,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        bad_input_share_0,
+        input_share_1,
+        test_vec_path,
+        "bad_leader_jr_blind",
+    )
+
+    # Modify helper joint randomness blind.
+    bad_input_share_1_temp = list(cast(tuple[Any, ...], input_share_1))
+    modified_helper_blind = bytearray(bad_input_share_1_temp[1])
+    modified_helper_blind[0] ^= 1
+    bad_input_share_1_temp[1] = modified_helper_blind
+    bad_input_share_1 = tuple(bad_input_share_1_temp)
+    _prio3_prep_shares_to_prep_failure(
+        prio3histogram,
+        verify_key,
+        nonce,
+        rand,
+        public_share,
+        input_share_0,
+        bad_input_share_1,
+        test_vec_path,
+        "bad_helper_jr_blind",
+    )
+
+    # Modify public share.
+    assert public_share is not None
+    bad_public_share = list(public_share)
+    modified_joint_rand_part = bytearray(bad_public_share[0])
+    modified_joint_rand_part[0] ^= 1
+    bad_public_share[0] = bytes(modified_joint_rand_part)
+    _prio3_prep_shares_to_prep_failure(
+        prio3histogram,
+        verify_key,
+        nonce,
+        rand,
+        bad_public_share,
+        input_share_0,
+        input_share_1,
+        test_vec_path,
+        "bad_public_share",
+    )
+
+
+def _prio3_prep_shares_to_prep_failure(
+        vdaf: Prio3,
+        verify_key: bytes,
+        nonce: bytes,
+        rand: bytes,
+        public_share: list[bytes] | None,
+        input_share_0: Prio3InputShare,
+        input_share_1: Prio3InputShare,
+        test_vec_path: str,
+        filename_suffix: str) -> None:
+    """
+    Takes in a corrupt report that will fail preparation during
+    prep_shares_to_prep, runs the preparation algorithms, and outputs a test
+    vector.
+    """
+    (_prep_state_0, prep_share_0) = vdaf.prep_init(
+        verify_key,
+        ctx,
+        0,
+        None,
+        nonce,
+        public_share,
+        input_share_0,
+    )
+    (_prep_state_1, prep_share_1) = vdaf.prep_init(
+        verify_key,
+        ctx,
+        1,
+        None,
+        nonce,
+        public_share,
+        input_share_1,
+    )
+    try:
+        vdaf.prep_shares_to_prep(ctx, None, [prep_share_0, prep_share_1])
+    except ValueError:
+        pass
+    else:
+        raise Exception("prep_shares_to_prep should fail")
+    test_vec: VdafTestVectorDict = {
+        'operations': [
+            {
+                'operation': 'prep_init',
+                'aggregator_id': 0,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_init',
+                'aggregator_id': 1,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_shares_to_prep',
+                'round': 0,
+                'report_index': 0,
+                'success': False,
+            },
+        ],
+        'shares': 2,
+        'verify_key': verify_key.hex(),
+        'agg_param': '',
+        'ctx': ctx.hex(),
+        'prep': [{
+            'measurement': None,
+            'rand': rand.hex(),
+            'nonce': nonce.hex(),
+            'public_share': vdaf.test_vec_encode_public_share(public_share).hex(),
+            'input_shares': [
+                vdaf.test_vec_encode_input_share(input_share_0).hex(),
+                vdaf.test_vec_encode_input_share(input_share_1).hex(),
+            ],
+            'prep_shares': [[
+                vdaf.test_vec_encode_prep_share(prep_share_0).hex(),
+                vdaf.test_vec_encode_prep_share(prep_share_1).hex(),
+            ]],
+            'prep_messages': [],
+            'out_shares': [],
+        }],
+        'agg_shares': [],
+        'agg_result': None,
+    }
+    type_params = vdaf.test_vec_set_type_param(
+        cast(dict[str, Any], test_vec)
+    )
+    pretty_print_vdaf_test_vec(
+        vdaf,
+        test_vec,
+        type_params,
+    )
+    write_test_vec(
+        test_vec_path,
+        test_vec,
+        vdaf.test_vec_name,
+        filename_suffix,
+    )
+
+
+def gen_poplar1_negative_test_vec(test_vec_path: str) -> None:
+    "Generates various negative test vectors for Poplar1"
+
+    vdaf = Poplar1(2)
+    nonce = test_vec_gen_rand(vdaf.NONCE_SIZE)
+    rand = test_vec_gen_rand(vdaf.RAND_SIZE)
+    measurement = (False, True)
+    public_share, [input_share_0, input_share_1] = vdaf.shard(
+        ctx,
+        measurement,
+        nonce,
+        rand,
+    )
+    verify_key = test_vec_gen_rand(vdaf.VERIFY_KEY_SIZE)
+    agg_param = (0, [(False,), (True,)])
+
+    # Modify correlated randomness.
+    bad_input_share_0_temp = list(input_share_0)
+    modified_correlated_randomness = list(
+        cast(list[Field64], bad_input_share_0_temp[2]))
+    modified_correlated_randomness[0] += Field64(1)
+    bad_input_share_0_temp[2] = modified_correlated_randomness
+    bad_input_share_0 = cast(Poplar1InputShare,
+                             tuple(bad_input_share_0_temp))
+    (prep_state_r0_a0, prep_share_r0_a0) = vdaf.prep_init(
+        verify_key,
+        ctx,
+        0,
+        agg_param,
+        nonce,
+        public_share,
+        bad_input_share_0,
+    )
+    (prep_state_r0_a1, prep_share_r0_a1) = vdaf.prep_init(
+        verify_key,
+        ctx,
+        1,
+        agg_param,
+        nonce,
+        public_share,
+        input_share_1,
+    )
+    prep_msg = vdaf.prep_shares_to_prep(
+        ctx,
+        agg_param,
+        [prep_share_r0_a0, prep_share_r0_a1],
+    )
+    (prep_state_r1_a0, prep_share_r1_a0) = vdaf.prep_next(
+        ctx,
+        prep_state_r0_a0,
+        prep_msg,
+    )
+    (prep_state_r1_a1, prep_share_r1_a1) = vdaf.prep_next(
+        ctx,
+        prep_state_r0_a1,
+        prep_msg,
+    )
+    try:
+        vdaf.prep_shares_to_prep(
+            ctx,
+            agg_param,
+            [
+                cast(FieldVec, prep_share_r1_a0),
+                cast(FieldVec, prep_share_r1_a1),
+            ],
+        )
+    except ValueError:
+        pass
+    else:
+        raise Exception("prep_shares_to_prep should fail")
+    test_vec: VdafTestVectorDict = {
+        'operations': [
+            {
+                'operation': 'prep_init',
+                'aggregator_id': 0,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_init',
+                'aggregator_id': 1,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_shares_to_prep',
+                'round': 0,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_next',
+                'round': 1,
+                'aggregator_id': 0,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_next',
+                'round': 1,
+                'aggregator_id': 1,
+                'report_index': 0,
+                'success': True,
+            },
+            {
+                'operation': 'prep_shares_to_prep',
+                'round': 1,
+                'report_index': 0,
+                'success': False,
+            },
+        ],
+        'shares': 2,
+        'verify_key': verify_key.hex(),
+        'agg_param': vdaf.encode_agg_param(agg_param).hex(),
+        'ctx': ctx.hex(),
+        'prep': [{
+            'measurement': None,
+            'rand': rand.hex(),
+            'nonce': nonce.hex(),
+            'public_share': vdaf.test_vec_encode_public_share(public_share).hex(),
+            'input_shares': [
+                vdaf.test_vec_encode_input_share(bad_input_share_0).hex(),
+                vdaf.test_vec_encode_input_share(input_share_1).hex(),
+            ],
+            'prep_shares': [
+                [
+                    vdaf.test_vec_encode_prep_share(prep_share_r0_a0).hex(),
+                    vdaf.test_vec_encode_prep_share(prep_share_r0_a1).hex(),
+                ],
+                [
+                    vdaf.test_vec_encode_prep_share(
+                        cast(FieldVec, prep_share_r1_a0)).hex(),
+                    vdaf.test_vec_encode_prep_share(
+                        cast(FieldVec, prep_share_r1_a1)).hex(),
+                ],
+            ],
+            'prep_messages': [
+                vdaf.test_vec_encode_prep_msg(prep_msg).hex(),
+            ],
+            'out_shares': [],
+        }],
+        'agg_shares': [],
+        'agg_result': None,
+    }
+    type_params = vdaf.test_vec_set_type_param(
+        cast(dict[str, Any], test_vec)
+    )
+    pretty_print_vdaf_test_vec(
+        vdaf,
+        test_vec,
+        type_params,
+    )
+    write_test_vec(
+        test_vec_path,
+        test_vec,
+        vdaf.test_vec_name,
+        "bad_corr_inner",
+    )
 
 
 if __name__ == '__main__':
@@ -340,3 +761,7 @@ if __name__ == '__main__':
     # XOFs
     gen_test_vec_for_xof(xof.XofTurboShake128)
     gen_test_vec_for_xof(xof.XofFixedKeyAes128)
+
+    gen_prio3_negative_test_vec(vdaf_test_vec_path)
+
+    gen_poplar1_negative_test_vec(vdaf_test_vec_path)

--- a/poc/gen_test_vec.py
+++ b/poc/gen_test_vec.py
@@ -103,7 +103,9 @@ def gen_test_vec_for_xof(cls: type[Xof]) -> None:
 
 
 def gen_prio3_negative_test_vec(test_vec_path: str) -> None:
-    "Generates various negative test vectors for Prio3"
+    """
+    Generates various negative test vectors for Prio3.
+    """
 
     prio3count = Prio3Count(2)
     nonce = test_vec_gen_rand(prio3count.NONCE_SIZE)
@@ -358,7 +360,9 @@ def _prio3_prep_shares_to_prep_failure(
 
 
 def gen_poplar1_negative_test_vec(test_vec_path: str) -> None:
-    "Generates various negative test vectors for Poplar1"
+    """
+    Generates various negative test vectors for Poplar1.
+    """
 
     vdaf = Poplar1(2)
     nonce = test_vec_gen_rand(vdaf.NONCE_SIZE)

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -224,7 +224,7 @@ def gen_test_vec_for_vdaf(
                 )
                 operations.append({
                     'operation': 'prep_next',
-                    'round': i,
+                    'round': i + 1,
                     'aggregator_id': j,
                     'report_index': report_index,
                     'success': True,
@@ -255,7 +255,7 @@ def gen_test_vec_for_vdaf(
             ])
             operations.append({
                 'operation': 'prep_next',
-                'round': vdaf.ROUNDS - 1,
+                'round': vdaf.ROUNDS,
                 'aggregator_id': j,
                 'report_index': report_index,
                 'success': True,

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from itertools import zip_longest
 from typing import (Any, Generic, Literal, NotRequired, Optional, TypedDict,
                     TypeVar, cast)
 
@@ -330,6 +331,16 @@ def pretty_print_vdaf_test_vec(
         type_params: list[str]) -> None:
     test_vec = cast(dict[str, Any], typed_test_vec)
     print('---------- {} ---------------'.format(vdaf.test_vec_name))
+    for (i, operation) in enumerate(typed_test_vec['operations']):
+        print('operation_{}:'.format(i))
+        print('  operation: "{}"'.format(operation['operation']))
+        if 'round' in operation:
+            print('  round: {}'.format(operation['round']))
+        if 'aggregator_id' in operation:
+            print('  aggregator_id: {}'.format(operation['aggregator_id']))
+        if 'report_index' in operation:
+            print('  report_index: {}'.format(operation['report_index']))
+        print('  success: {}'.format(operation['success']))
     for type_param in type_params:
         print('{}: {}'.format(type_param, test_vec[type_param]))
     print('verify_key: "{}"'.format(test_vec['verify_key']))
@@ -350,14 +361,15 @@ def pretty_print_vdaf_test_vec(
 
         # Prepare
         for (i, (prep_shares, prep_msg)) in enumerate(
-                zip(prep_test_vec['prep_shares'],
-                    prep_test_vec['prep_messages'])):
+                zip_longest(prep_test_vec['prep_shares'],
+                            prep_test_vec['prep_messages'])):
             print('  round_{}:'.format(i))
             for (j, prep_share) in enumerate(prep_shares):
                 print('    prep_share_{}: >-'.format(j))
                 print_wrapped_line(prep_share, tab=6)
-            print('    prep_message: >-')
-            print_wrapped_line(prep_msg, tab=6)
+            if prep_msg is not None:
+                print('    prep_message: >-')
+                print_wrapped_line(prep_msg, tab=6)
 
         for (j, out_shares) in enumerate(prep_test_vec['out_shares']):
             print('  out_share_{}:'.format(j))

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -122,7 +122,8 @@ def gen_test_vec_for_vdaf(
         ctx: bytes,
         measurements: list[Measurement],
         test_vec_instance: int,
-        print_test_vec: bool = True) -> AggResult:
+        print_test_vec: bool = True) -> \
+        VdafTestVectorDict[Measurement, AggParam, AggResult]:
     """
     Generate test vectors for successful evaluation of a VDAF.
     """
@@ -305,7 +306,7 @@ def gen_test_vec_for_vdaf(
             json.dump(test_vec, f, indent=4, sort_keys=True)
             f.write('\n')
 
-    return agg_result
+    return test_vec
 
 
 def _pretty_print_vdaf_test_vec(

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -294,22 +294,35 @@ def gen_test_vec_for_vdaf(
     })
 
     if print_test_vec:
-        _pretty_print_vdaf_test_vec(vdaf, test_vec, type_params)
-
-        os.system('mkdir -p {}'.format(test_vec_path))
-        filename = '{}/{}_{}.json'.format(
+        pretty_print_vdaf_test_vec(vdaf, test_vec, type_params)
+        write_test_vec(
             test_vec_path,
+            test_vec,
             vdaf.test_vec_name,
-            test_vec_instance,
+            str(test_vec_instance),
         )
-        with open(filename, 'w', encoding="UTF-8") as f:
-            json.dump(test_vec, f, indent=4, sort_keys=True)
-            f.write('\n')
 
     return test_vec
 
 
-def _pretty_print_vdaf_test_vec(
+def write_test_vec(
+        test_vec_path: str,
+        test_vec: VdafTestVectorDict[Measurement, AggParam, AggResult],
+        test_vec_name: str,
+        test_vec_suffix: str) -> None:
+    "Write a test vector to a JSON file"
+    os.system('mkdir -p {}'.format(test_vec_path))
+    filename = '{}/{}_{}.json'.format(
+        test_vec_path,
+        test_vec_name,
+        test_vec_suffix,
+    )
+    with open(filename, 'w', encoding="UTF-8") as f:
+        json.dump(test_vec, f, indent=4, sort_keys=True)
+        f.write('\n')
+
+
+def pretty_print_vdaf_test_vec(
         vdaf: Vdaf[
             Measurement, AggParam, Any, Any, Any, Any, AggResult, Any, Any, Any
         ],

--- a/poc/vdaf_poc/vdaf_prio3.py
+++ b/poc/vdaf_poc/vdaf_prio3.py
@@ -154,6 +154,7 @@ class Prio3(
             assert joint_rand_parts is not None
             joint_rand_part = self.joint_rand_part(
                 ctx, agg_id, blind, meas_share, nonce)
+            joint_rand_parts = list(joint_rand_parts)
             joint_rand_parts[agg_id] = joint_rand_part
             corrected_joint_rand_seed = self.joint_rand_seed(
                 ctx, joint_rand_parts)

--- a/test_vec/vdaf/Poplar1_0.json
+++ b/test_vec/vdaf/Poplar1_0.json
@@ -10,6 +10,79 @@
     ],
     "bits": 4,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_0.json
+++ b/test_vec/vdaf/Poplar1_0.json
@@ -38,14 +38,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -58,14 +58,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_1.json
+++ b/test_vec/vdaf/Poplar1_1.json
@@ -40,14 +40,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -60,14 +60,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_1.json
+++ b/test_vec/vdaf/Poplar1_1.json
@@ -12,6 +12,79 @@
     ],
     "bits": 4,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_2.json
+++ b/test_vec/vdaf/Poplar1_2.json
@@ -40,14 +40,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -60,14 +60,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_2.json
+++ b/test_vec/vdaf/Poplar1_2.json
@@ -12,6 +12,79 @@
     ],
     "bits": 4,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_3.json
+++ b/test_vec/vdaf/Poplar1_3.json
@@ -15,6 +15,79 @@
     ],
     "bits": 4,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_3.json
+++ b/test_vec/vdaf/Poplar1_3.json
@@ -43,14 +43,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -63,14 +63,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_4.json
+++ b/test_vec/vdaf/Poplar1_4.json
@@ -38,14 +38,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -58,14 +58,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_4.json
+++ b/test_vec/vdaf/Poplar1_4.json
@@ -10,6 +10,79 @@
     ],
     "bits": 11,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_5.json
+++ b/test_vec/vdaf/Poplar1_5.json
@@ -40,14 +40,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -60,14 +60,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 1,
+            "round": 2,
             "success": true
         },
         {

--- a/test_vec/vdaf/Poplar1_5.json
+++ b/test_vec/vdaf/Poplar1_5.json
@@ -12,6 +12,79 @@
     ],
     "bits": 11,
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Poplar1_bad_corr_inner.json
+++ b/test_vec/vdaf/Poplar1_bad_corr_inner.json
@@ -1,0 +1,75 @@
+{
+    "agg_param": "0000000000020080",
+    "agg_result": null,
+    "agg_shares": [],
+    "bits": 2,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 1,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "000102030405060708090a0b0c0d0e0f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f7f7dc6345cc6ddcbef04145502a6731d843077536603fd1d809d8364bc6fdddfb38b7bf53bb5f4d9d2ea3d8a452f866f63ef5cecb829d29a7b0a06e0c9536cf5d40dc59674ee759be1a70f2a4bec854b",
+                "101112131415161718191a1b1c1d1e1f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5fc46de59d5a8c91b0187d22016323cdb06752ae15a1277011caf754974e5f9c7b51bbb6f537f446f4b99414f0cfd31e34568278b83ac975508853807b1b9d27cef5e2ee3d4d8436ad7f3c82bd56101979"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [
+                "ccbdb1ceb7889a61ad01079573109f5e2039c58a0b824be3"
+            ],
+            "prep_shares": [
+                [
+                    "8bc6b288a2b65d77339a9eac14ae20c0fbe1171bc494b8f6",
+                    "42f7fe4514d23cea7b6768e85d627e9e2657ad6f46ed92ec"
+                ],
+                [
+                    "b0f2002275ecc7e4",
+                    "1dcbb0ac419cd27c"
+                ]
+            ],
+            "public_share": "01e4a750964ed1ae57542b1ebe0b0a08fefa73ea0dcb3423d084fd14e0bc3c1cffedfcc77e47eba098eabc56eb019dd6d5dbb10b924c32b54262a597d36a3df95d3b2f5031d7cabee88418350ceb0c0f7a2b19cbebe6a50bdb83fd5f9c94f469b23eb38c3469f3c72ebd725e92a7011670",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Count_0.json
+++ b/test_vec/vdaf/Prio3Count_0.json
@@ -34,14 +34,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Count_0.json
+++ b/test_vec/vdaf/Prio3Count_0.json
@@ -6,6 +6,59 @@
         "1f96fa976d56026a"
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Count_1.json
+++ b/test_vec/vdaf/Prio3Count_1.json
@@ -41,21 +41,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Count_1.json
+++ b/test_vec/vdaf/Prio3Count_1.json
@@ -7,6 +7,77 @@
         "359d14a56320fcd7"
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Count_2.json
+++ b/test_vec/vdaf/Prio3Count_2.json
@@ -6,6 +6,207 @@
         "99eee4f725b00b12"
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Count_2.json
+++ b/test_vec/vdaf/Prio3Count_2.json
@@ -34,14 +34,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -71,14 +71,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -108,14 +108,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -145,14 +145,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -182,14 +182,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Count_bad_gadget_poly.json
+++ b/test_vec/vdaf/Prio3Count_bad_gadget_poly.json
@@ -1,0 +1,48 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e369056891a9fd95d44e6fadb3b75e6774b666d312bcc59b57694d189321ffe06f46b37d26db61d057b17152e3726a2e",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "5d6a0685bd0f0aa9b19b8c1c4431ec49eca02338e5e05da8cfd95bffb57f21f0",
+                    "a595f97a41f0f5565abc07086ef01d5b3cb2629a3c534bd4dbd8f5187ad75aad"
+                ]
+            ],
+            "public_share": "",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Count_bad_helper_seed.json
+++ b/test_vec/vdaf/Prio3Count_bad_helper_seed.json
@@ -1,0 +1,48 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e369056891a9fd95d44e6fadb3b75e6774b666d312bcc59b57694d189321ffe06f46b37d26db61d056b17152e3726a2e",
+                "010102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "5c6a0685bd0f0aa9b19b8c1c4431ec49eca02338e5e05da8fc91575311627200",
+                    "1e3f9484477e86edb9b7c743b75f9b7c81f5ab0d9c1812eac73918b7633ab8ef"
+                ]
+            ],
+            "public_share": "",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Count_bad_meas_share.json
+++ b/test_vec/vdaf/Prio3Count_bad_meas_share.json
@@ -1,0 +1,48 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e469056891a9fd95d44e6fadb3b75e6774b666d312bcc59b57694d189321ffe06f46b37d26db61d056b17152e3726a2e",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "5b6a0685bd0f0aa9d77d58a46740003f1283efbf08f0719dfc91575311627200",
+                    "a595f97a41f0f5565abc07086ef01d5b3cb2629a3c534bd4dbd8f5187ad75aad"
+                ]
+            ],
+            "public_share": "",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Count_bad_wire_seed.json
+++ b/test_vec/vdaf/Prio3Count_bad_wire_seed.json
@@ -1,0 +1,48 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e369056891a9fd95d54e6fadb3b75e6774b666d312bcc59b57694d189321ffe06f46b37d26db61d056b17152e3726a2e",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "5c6a0685bd0f0aa98cb9c0942022d854eca02338e5e05da8fc91575311627200",
+                    "a595f97a41f0f5565abc07086ef01d5b3cb2629a3c534bd4dbd8f5187ad75aad"
+                ]
+            ],
+            "public_share": "",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Histogram_0.json
+++ b/test_vec/vdaf/Prio3Histogram_0.json
@@ -13,6 +13,59 @@
     "chunk_length": 2,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 4,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Histogram_0.json
+++ b/test_vec/vdaf/Prio3Histogram_0.json
@@ -41,14 +41,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Histogram_1.json
+++ b/test_vec/vdaf/Prio3Histogram_1.json
@@ -55,21 +55,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Histogram_1.json
+++ b/test_vec/vdaf/Prio3Histogram_1.json
@@ -21,6 +21,77 @@
     "chunk_length": 3,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 11,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Histogram_2.json
+++ b/test_vec/vdaf/Prio3Histogram_2.json
@@ -137,14 +137,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -174,14 +174,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -211,14 +211,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -248,14 +248,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -285,14 +285,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -322,14 +322,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 5,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 5,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -359,14 +359,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 6,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 6,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -396,14 +396,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 7,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 7,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -433,14 +433,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 8,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 8,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -470,14 +470,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 9,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 9,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Histogram_2.json
+++ b/test_vec/vdaf/Prio3Histogram_2.json
@@ -109,6 +109,392 @@
     "chunk_length": 10,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 100,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 8,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 8,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 8,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 8,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 8,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 8,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 9,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 9,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 9,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 9,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 9,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 9,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Histogram_bad_helper_jr_blind.json
+++ b/test_vec/vdaf/Prio3Histogram_bad_helper_jr_blind.json
@@ -1,0 +1,50 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "chunk_length": 2,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "length": 5,
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e720f2d625ee3cabce61d583c8c4054e82e8487025764348020264792b3d100f0c8c76f65caf04ee0e22373be0d61ac5fb6e2f2866078b31b90537e24416fad12aa44b74bb71c2548b15f78fb0d8a308d878d8b7b93954e80a0a008ae08698e74409c646c5089bf508d7b32589a4442c84c94b77dd83e10d4cbdcb0a8e9084ba58812ef6c40e078587f3c82140facd7edd1d134c8fe77e054cbbe3b201fe287e73f802d264126d1cd1e62d26dc8210f3f4c294a90eeccd07a4649b3d86dd24f4995ffd32815553c38fc0ce8a7963e9751cf2fa51a65aa766662c98cea401dd92fe35d43616ad86c5561f86d8a3cbce6eb4e78e8480b98c28947ee90cf48f86d0404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f212122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "3fd4a2beffc4c823c1acf8f9a39773bdaec27f14225d18fe7de98864b3e88d9d55712f54e38d387cc86b316d537b5915ad15d319f7c9a462ca89babe10efc0ca8ee86d85f34038cd4ea89ba1678651b5c1ee2d3352368b9f5970d970d0516dc718d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd",
+                    "c22b5d41003b37dc225307065c688c42d9ac64500286b6c07d959e5b538d02a6f72dbfccac57b6520b59c9c41e290353f9fb383862ac7f3ed5f7172720af40241d58c2c93fd0f48cda4ea3561ef0f7809da23642e48ae655de8c7e6b008ab43b1207614dc8f0ea32fced4985e6635b5cbf4415fc1a52a72198a041faaec04e8e"
+                ]
+            ],
+            "public_share": "18d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Histogram_bad_leader_jr_blind.json
+++ b/test_vec/vdaf/Prio3Histogram_bad_leader_jr_blind.json
@@ -1,0 +1,50 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "chunk_length": 2,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "length": 5,
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e720f2d625ee3cabce61d583c8c4054e82e8487025764348020264792b3d100f0c8c76f65caf04ee0e22373be0d61ac5fb6e2f2866078b31b90537e24416fad12aa44b74bb71c2548b15f78fb0d8a308d878d8b7b93954e80a0a008ae08698e74409c646c5089bf508d7b32589a4442c84c94b77dd83e10d4cbdcb0a8e9084ba58812ef6c40e078587f3c82140facd7edd1d134c8fe77e054cbbe3b201fe287e73f802d264126d1cd1e62d26dc8210f3f4c294a90eeccd07a4649b3d86dd24f4995ffd32815553c38fc0ce8a7963e9751cf2fa51a65aa766662c98cea401dd92fe35d43616ad86c5561f86d8a3cbce6eb4e78e8480b98c28947ee90cf48f86d0414142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "3fd4a2beffc4c823c1acf8f9a39773bdb6fe15e8ca56227629d36ae852b46bbd55712f54e38d387cc86b316d537b591585d2c9264ae9a8f8e9fc597ad27260548ee86d85f34038cd4ea89ba1678651b5c1ee2d3352368b9f5970d970d0516dc71ecf2e9a6ebf3c59383c3a00db5547122c589eb77981ca940c715ba7dcd1b302",
+                    "c22b5d41003b37dc225307065c688c428f7aa7727ac876d478bb84fe406cb567f72dbfccac57b6520b59c9c41e2903530e961aa15a8181f92cfd667cf115ae831d58c2c93fd0f48cda4ea3561ef0f7809da23642e48ae655de8c7e6b008ab43b01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337"
+                ]
+            ],
+            "public_share": "18d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Histogram_bad_prep_msg.json
+++ b/test_vec/vdaf/Prio3Histogram_bad_prep_msg.json
@@ -1,0 +1,46 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "chunk_length": 2,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "length": 5,
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 1,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e720f2d625ee3cabce61d583c8c4054e82e8487025764348020264792b3d100f0c8c76f65caf04ee0e22373be0d61ac5fb6e2f2866078b31b90537e24416fad12aa44b74bb71c2548b15f78fb0d8a308d878d8b7b93954e80a0a008ae08698e74409c646c5089bf508d7b32589a4442c84c94b77dd83e10d4cbdcb0a8e9084ba58812ef6c40e078587f3c82140facd7edd1d134c8fe77e054cbbe3b201fe287e73f802d264126d1cd1e62d26dc8210f3f4c294a90eeccd07a4649b3d86dd24f4995ffd32815553c38fc0ce8a7963e9751cf2fa51a65aa766662c98cea401dd92fe35d43616ad86c5561f86d8a3cbce6eb4e78e8480b98c28947ee90cf48f86d0404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "prep_shares": [
+                [
+                    "3fd4a2beffc4c823c1acf8f9a39773bdaec27f14225d18fe7de98864b3e88d9d55712f54e38d387cc86b316d537b5915ad15d319f7c9a462ca89babe10efc0ca8ee86d85f34038cd4ea89ba1678651b5c1ee2d3352368b9f5970d970d0516dc718d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd"
+                ]
+            ],
+            "public_share": "18d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3Histogram_bad_public_share.json
+++ b/test_vec/vdaf/Prio3Histogram_bad_public_share.json
@@ -1,0 +1,50 @@
+{
+    "agg_param": "",
+    "agg_result": null,
+    "agg_shares": [],
+    "chunk_length": 2,
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "length": 5,
+    "operations": [
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": false
+        }
+    ],
+    "prep": [
+        {
+            "input_shares": [
+                "e720f2d625ee3cabce61d583c8c4054e82e8487025764348020264792b3d100f0c8c76f65caf04ee0e22373be0d61ac5fb6e2f2866078b31b90537e24416fad12aa44b74bb71c2548b15f78fb0d8a308d878d8b7b93954e80a0a008ae08698e74409c646c5089bf508d7b32589a4442c84c94b77dd83e10d4cbdcb0a8e9084ba58812ef6c40e078587f3c82140facd7edd1d134c8fe77e054cbbe3b201fe287e73f802d264126d1cd1e62d26dc8210f3f4c294a90eeccd07a4649b3d86dd24f4995ffd32815553c38fc0ce8a7963e9751cf2fa51a65aa766662c98cea401dd92fe35d43616ad86c5561f86d8a3cbce6eb4e78e8480b98c28947ee90cf48f86d0404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            ],
+            "measurement": null,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [],
+            "prep_messages": [],
+            "prep_shares": [
+                [
+                    "3fd4a2beffc4c823c1acf8f9a39773bdaec27f14225d18fe7de98864b3e88d9d55712f54e38d387cc86b316d537b5915ad15d319f7c9a462ca89babe10efc0ca8ee86d85f34038cd4ea89ba1678651b5c1ee2d3352368b9f5970d970d0516dc718d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd",
+                    "c22b5d41003b37dc225307065c688c4254584ecbc8bb6b3be66dcf3c58ab4c11f72dbfccac57b6520b59c9c41e290353cebfb8098b1b94489e50eeae2ead5f6d1d58c2c93fd0f48cda4ea3561ef0f7809da23642e48ae655de8c7e6b008ab43b01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337"
+                ]
+            ],
+            "public_share": "19d1fa6a203f562af224e6bb7cf1b465db06678b71c764bc793755fd5d1f4bcd01a98d76e07e02ee3f6c9055b3cbb73cdfd67c4dabf30d9323b93e327122e337",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}

--- a/test_vec/vdaf/Prio3MultihotCountVec_0.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_0.json
@@ -42,14 +42,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3MultihotCountVec_0.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_0.json
@@ -14,6 +14,59 @@
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 4,
     "max_weight": 2,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3MultihotCountVec_1.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_1.json
@@ -62,28 +62,28 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 3,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3MultihotCountVec_1.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_1.json
@@ -22,6 +22,95 @@
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 10,
     "max_weight": 2,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 3,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 3,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 3,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3MultihotCountVec_2.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_2.json
@@ -14,6 +14,207 @@
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 4,
     "max_weight": 4,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3MultihotCountVec_2.json
+++ b/test_vec/vdaf/Prio3MultihotCountVec_2.json
@@ -42,14 +42,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -79,14 +79,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -116,14 +116,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -153,14 +153,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -190,14 +190,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3SumVecWithMultiproof_0.json
+++ b/test_vec/vdaf/Prio3SumVecWithMultiproof_0.json
@@ -48,14 +48,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -85,14 +85,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -122,14 +122,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3SumVecWithMultiproof_0.json
+++ b/test_vec/vdaf/Prio3SumVecWithMultiproof_0.json
@@ -20,6 +20,133 @@
     "chunk_length": 9,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 10,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3SumVecWithMultiproof_1.json
+++ b/test_vec/vdaf/Prio3SumVecWithMultiproof_1.json
@@ -14,6 +14,177 @@
     "chunk_length": 7,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 3,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3SumVecWithMultiproof_1.json
+++ b/test_vec/vdaf/Prio3SumVecWithMultiproof_1.json
@@ -48,21 +48,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -98,21 +98,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -148,21 +148,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3SumVec_0.json
+++ b/test_vec/vdaf/Prio3SumVec_0.json
@@ -48,14 +48,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -85,14 +85,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -122,14 +122,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3SumVec_0.json
+++ b/test_vec/vdaf/Prio3SumVec_0.json
@@ -20,6 +20,133 @@
     "chunk_length": 9,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 10,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3SumVec_1.json
+++ b/test_vec/vdaf/Prio3SumVec_1.json
@@ -14,6 +14,177 @@
     "chunk_length": 7,
     "ctx": "736f6d65206170706c69636174696f6e",
     "length": 3,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3SumVec_1.json
+++ b/test_vec/vdaf/Prio3SumVec_1.json
@@ -48,21 +48,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -98,21 +98,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -148,21 +148,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Sum_0.json
+++ b/test_vec/vdaf/Prio3Sum_0.json
@@ -35,14 +35,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Sum_0.json
+++ b/test_vec/vdaf/Prio3Sum_0.json
@@ -7,6 +7,59 @@
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
     "max_measurement": 255,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Sum_1.json
+++ b/test_vec/vdaf/Prio3Sum_1.json
@@ -42,21 +42,21 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 2,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Sum_1.json
+++ b/test_vec/vdaf/Prio3Sum_1.json
@@ -8,6 +8,77 @@
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
     "max_measurement": 255,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 2,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [

--- a/test_vec/vdaf/Prio3Sum_2.json
+++ b/test_vec/vdaf/Prio3Sum_2.json
@@ -35,14 +35,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 0,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -72,14 +72,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 1,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -109,14 +109,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 2,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -146,14 +146,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 3,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -183,14 +183,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 4,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -220,14 +220,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 5,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 5,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -257,14 +257,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 6,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 6,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
@@ -294,14 +294,14 @@
             "aggregator_id": 0,
             "operation": "prep_next",
             "report_index": 7,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {
             "aggregator_id": 1,
             "operation": "prep_next",
             "report_index": 7,
-            "round": 0,
+            "round": 1,
             "success": true
         },
         {

--- a/test_vec/vdaf/Prio3Sum_2.json
+++ b/test_vec/vdaf/Prio3Sum_2.json
@@ -7,6 +7,318 @@
     ],
     "ctx": "736f6d65206170706c69636174696f6e",
     "max_measurement": 1337,
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 1,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 1,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 2,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 2,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 3,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 3,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 4,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 4,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 5,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 5,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 6,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 6,
+            "round": 0,
+            "success": true
+        },
+        {
+            "operation": "shard",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_init",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_init",
+            "report_index": 7,
+            "success": true
+        },
+        {
+            "operation": "prep_shares_to_prep",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "prep_next",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "prep_next",
+            "report_index": 7,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
     "prep": [
         {
             "input_shares": [


### PR DESCRIPTION
This extends the test vector file format to support negative test vectors. Each file now includes a list of which operations should be run using its messages, and whether they should succeed or fail. Thus, we can represent a report that could never be produced by the sharding algorithm, skip comparing against the shard implementation, and check what happens in each step of the preparation process with that input. I include eight new negative test vectors to start with. Existing test vectors are modified to add this list of operations. Note that test vector consumers do not necessarily need to reimplement `run_vdaf()` anymore to make use of the all-success test vectors, since the operations list now captures that high-level coordination.

Up until now, we have not had strong conventions for "round numbers" to associate with every message or operation. I'm open to suggestions on whether we should adjust the round numbers used for "prep_shares_to_prep" or "prep_next" operations.

I'm working on consuming these negative test vectors in libprio-rs, and thus far I'm getting partial mismatches of Prio3 prepare shares when either the helper's joint randomness blind or the public share is corrupted (but not the leader's joint randomness blind, interestingly). It's possible we have some error in the implementation that cancels out when there's agreement on the joint randomness seed.

Closes #536.