### PR TITLE
Fix mypy errors

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -4865,7 +4865,10 @@ def prep_init(
         list[Field],
         verify_rand_xof.next_vec(field, len(prefixes)),
     )
-    sketch_share = [a_share, b_share, c_share]
+    sketch_share = cast(
+        list[Field],
+        [a_share, b_share, c_share],
+    )
     out_share = []
     for (i, r) in enumerate(verify_rand):
         data_share = cast(Field, value[i][0])

--- a/poc/vdaf_poc/vdaf_poplar1.py
+++ b/poc/vdaf_poc/vdaf_poplar1.py
@@ -288,7 +288,10 @@ class Poplar1(
             list[Field],
             verify_rand_xof.next_vec(field, len(prefixes)),
         )
-        sketch_share = [a_share, b_share, c_share]
+        sketch_share = cast(
+            list[Field],
+            [a_share, b_share, c_share],
+        )
         out_share = []
         for (i, r) in enumerate(verify_rand):
             data_share = cast(Field, value[i][0])


### PR DESCRIPTION
I upgraded mypy from 1.10.0 to 1.15.0, and it found some new type errors. This PR adds another cast to Poplar1 sketching to hop between `Field64 | Field255` to `Field`.