### PR TITLE
topo: Merge outbound into state

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1614,22 +1614,24 @@ channel.
 The state machine of each Aggregator is shown below.
 
 ~~~ aasvg
-                  +----------------+
-                  |                |
-                  v                |
-Start ----> Continued(prep_state, prep_round) --> Finished(out_share)
- |                |
- |                |
- +--> Rejected <--+
+ +--> Rejected <--+   +----------------+   Finished(out_share)
+ |                |   |                |           ^
+ |                |   |                v           |
+Start ----> Continued(prep_state, prep_round, outbound)
+ |                                                 |
+ |                                                 v
+ +-----------------> FinishedWithOutbound(out_share, outbound)
 ~~~
 {: #vdaf-prep-state-machine title="State machine of VDAF preparation."}
 
 State transitions are made when the state is acted upon by the Aggregator's
 local inputs and/or messages sent by its co-Aggregators. The initial state is
 `Start`. The terminal states are: `Rejected`, indicating that the report cannot
-be processed any further; and `Finished(out_share)`, indicating that the
-Aggregator has recovered an output share `out_share`. For completeness, we
-define these states in {{topo-states}}.
+be processed any further; `Finished(out_share)`, indicating that the
+Aggregator has recovered an output share `out_share`; and
+`FinishedWithOutbound(out_share, outbound)`, indicating that the Aggregator has
+recovered an output share, and has one more outbound message to send. For
+completeness, we define these states in {{topo-states}}.
 
 The methods described in this section are defined in terms of opaque byte
 strings. A compatible `Vdaf` MUST specify methods for encoding public shares,
@@ -1709,7 +1711,7 @@ def ping_pong_leader_init(
         agg_param: bytes,
         nonce: bytes,
         public_share: bytes,
-        input_share: bytes) -> tuple[State, Optional[bytes]]:
+        input_share: bytes) -> Continued | Rejected:
     """Called by the Leader to initialize ping-ponging."""
     try:
         (prep_state, prep_share) = self.prep_init(
@@ -1721,20 +1723,22 @@ def ping_pong_leader_init(
             self.decode_public_share(public_share),
             self.decode_input_share(0, input_share),
         )
+
         encoded_prep_share = self.encode_prep_share(prep_share)
-        return (
-            Continued(prep_state, 0),
+        return Continued(
+            prep_state, 0,
             encode(0, encoded_prep_share),  # initialize
         )
     except:
-        return (Rejected(), None)
+        return Rejected()
 ~~~
 
-The output is the `State` to which the Leader has transitioned and an encoded
-`Message`. If the Leader's state is `Rejected`, then processing halts.
-Otherwise, if the state is `Continued`, then processing continues. The function
-`encode`  is used to encode the outbound message, which has the message type of
-`initialize` (identified by the number `0`).
+The output is the `State` to which the Leader has transitioned. If the Leader's
+state is `Rejected`, then processing halts. Otherwise, if the state is
+`Continued`, then processing continues. In this case, the state also includes
+the Leader's outbound message. The function `encode` is used to encode the
+outbound message, which has the message type of `initialize` (identified by the
+number `0`).
 
 To continue processing the report, the Leader sends the outbound message to the
 Helper. The Helper's initial transition is computed using the following
@@ -1742,18 +1746,20 @@ procedure:
 
 ~~~ python
 def ping_pong_helper_init(
-        self,
-        vdaf_verify_key: bytes,
-        ctx: bytes,
-        agg_param: bytes,
-        nonce: bytes,
-        public_share: bytes,
-        input_share: bytes,
-        inbound: bytes) -> tuple[State, Optional[bytes]]:
+    self,
+    vdaf_verify_key: bytes,
+    ctx: bytes,
+    agg_param: bytes,
+    nonce: bytes,
+    public_share: bytes,
+    input_share: bytes,
+    inbound: bytes,  # encoded ping pong Message
+) -> Continued | FinishedWithOutbound | Rejected:
     """
     Called by the Helper in response to the Leader's initial
     message.
     """
+
     try:
         (prep_state, prep_share) = self.prep_init(
             vdaf_verify_key,
@@ -1767,7 +1773,7 @@ def ping_pong_helper_init(
 
         (inbound_type, inbound_items) = decode(inbound)
         if inbound_type != 0:  # initialize
-            return (Rejected(), None)
+            return Rejected()
 
         encoded_prep_share = inbound_items[0]
         prep_shares = [
@@ -1782,7 +1788,7 @@ def ping_pong_helper_init(
             0,
         )
     except:
-        return (Rejected(), None)
+        return Rejected()
 ~~~
 
 The procedure `decode()` decodes the inbound message and returns the
@@ -1798,29 +1804,30 @@ def ping_pong_transition(
         agg_param: AggParam,
         prep_shares: list[PrepShare],
         prep_state: PrepState,
-        prep_round: int) -> tuple[State, bytes]:
+        prep_round: int) -> Continued | FinishedWithOutbound:
     prep_msg = self.prep_shares_to_prep(ctx,
                                         agg_param,
                                         prep_shares)
     encoded_prep_msg = self.encode_prep_msg(prep_msg)
     out = self.prep_next(ctx, prep_state, prep_msg)
     if prep_round+1 == self.ROUNDS:
-        return (
-            Finished(out),
+        return FinishedWithOutbound(
+            out,
             encode(2, encoded_prep_msg),  # finalize
         )
     (prep_state, prep_share) = cast(
         tuple[PrepState, PrepShare], out)
     encoded_prep_share = self.encode_prep_share(prep_share)
-    return (
-        Continued(prep_state, prep_round+1),
+    return Continued(
+        prep_state, prep_round+1,
         encode(1, encoded_prep_msg, encoded_prep_share)  # continue
     )
 ~~~
 
-The output is the `State` to which the Helper has transitioned and an encoded
-`Message`. If the Helper's state is `Finished` or `Rejected`, then processing
-halts. Otherwise, if the state is `Continued`, then processing continues.
+The output is the `State` to which the Helper has transitioned. If the Helper's
+state is `Finished` or `Rejected`, then processing halts. Otherwise, if the
+state is `Continued` or `FinishedWithOutbound`, then the state include an
+outbound message and processing continues.
 
 To continue processing, the Helper sends the outbound message to the Leader.
 The Leader computes its next state transition using the following method on
@@ -1831,9 +1838,9 @@ def ping_pong_leader_continued(
     self,
     ctx: bytes,
     agg_param: bytes,
-    state: State,
-    inbound: bytes,
-) -> tuple[State, Optional[bytes]]:
+    state: Continued,
+    inbound: bytes,  # encoded ping pong Message
+) -> State:
     """
     Called by the Leader to start the next step of ping-ponging.
     """
@@ -1845,17 +1852,15 @@ def ping_pong_continued(
     is_leader: bool,
     ctx: bytes,
     agg_param: bytes,
-    state: State,
-    inbound: bytes,
-) -> tuple[State, Optional[bytes]]:
+    state: Continued,
+    inbound: bytes,  # encoded ping pong Message
+) -> State:
     try:
-        if not isinstance(state, Continued):
-            return (Rejected(), None)
         prep_round = state.prep_round
 
         (inbound_type, inbound_items) = decode(inbound)
         if inbound_type == 0:  # initialize
-            return (Rejected(), None)
+            return Rejected()
 
         encoded_prep_msg = inbound_items[0]
         prep_msg = self.decode_prep_msg(
@@ -1886,25 +1891,26 @@ def ping_pong_continued(
             )
         elif prep_round+1 == self.ROUNDS and \
                 inbound_type == 2:  # finish
-            return (Finished(out), None)
+            return Finished(out)
         else:
-            return (Rejected(), None)
+            return Rejected()
     except:
-        return (Rejected(), None)
+        return Rejected()
 ~~~
 
 If the Leader's state is `Finished` or `Rejected`, then processing halts.
-Otherwise, the Leader sends the outbound message to the Helper. The Helper
-computes its next state transition using the following method on class `Vdaf`:
+Otherwise, if the Leader's state is `Continued` or `FinishedWithOutbound`, the
+Leader sends the outbound message to the Helper. The Helper computes its next
+state transition using the following method on class `Vdaf`:
 
 ~~~ python
 def ping_pong_helper_continued(
     self,
     ctx: bytes,
     agg_param: bytes,
-    state: State,
-    inbound: bytes,
-) -> tuple[State, Optional[bytes]]:
+    state: Continued,
+    inbound: bytes,  # encoded ping pong Message
+) -> State:
     """Called by the Helper to continue ping-ponging."""
     return self.ping_pong_continued(
         False, ctx, agg_param, state, inbound)
@@ -6262,14 +6268,19 @@ class Start(State):
     pass
 
 class Continued(State, Generic[PrepState]):
-    def __init__(self, prep_state: PrepState, prep_round: int):
+    def __init__(self,
+                 prep_state: PrepState,
+                 prep_round: int,
+                 outbound: bytes):
         self.prep_state = prep_state
         self.prep_round = prep_round
+        self.outbound = outbound
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Continued) and \
             self.prep_state == other.prep_state and \
-            self.prep_round == other.prep_round
+            self.prep_round == other.prep_round and \
+            self.outbound == other.outbound
 
 class Finished(State, Generic[OutShare]):
     def __init__(self, out_share: OutShare):
@@ -6278,6 +6289,16 @@ class Finished(State, Generic[OutShare]):
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Finished) and \
             self.out_share == other.out_share
+
+class FinishedWithOutbound(State, Generic[OutShare]):
+    def __init__(self, out_share: OutShare, outbound: bytes):
+        self.out_share = out_share
+        self.outbound = outbound
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FinishedWithOutbound) and \
+            self.out_share == other.out_share and \
+            self.outbound == other.outbound
 
 class Rejected(State):
     pass


### PR DESCRIPTION
Closes #542.

Merge the outbound message into the Aggregator's ping pong state:

1. Remove outbound message from each API call

2. Add outbound message to `Continued`

3. Define a new state, `FinishedWithOutbound` that is like `Finished` except it include an outbound message

This reduces the number of cases the caller has to handle to only cases that are valid. In particular, the following cases are invalid:

* `state == Rejected() and outbound != None`
* `state == Continued(...) and outbound == None`