### PR TITLE
Ping pong topo

### DIFF
--- a/poc/tests/test_vdaf_ping_pong.py
+++ b/poc/tests/test_vdaf_ping_pong.py
@@ -19,7 +19,7 @@ class PingPongTester(
             int,  # AggShare
             int,  # AggResult
             tuple[int, int],  # PrepState
-            str,  # PrepShhare
+            str,  # PrepShare
             str,  # PrepMessage
         ]):
     """
@@ -83,7 +83,7 @@ class PingPongTester(
                   prep_msg: str) -> Union[tuple[tuple[int, int], str], int]:
         (current_round, out_share) = prep_state
         if prep_msg != "prep round {}".format(current_round):
-            raise ValueError("unexpted prep message")
+            raise ValueError(f"unexpected prep message {prep_msg}")
         if current_round+1 == self.ROUNDS:
             return out_share
         return (
@@ -204,7 +204,7 @@ class TestPingPong(unittest.TestCase):
             nonce,
             vdaf.test_vec_encode_public_share(public_share),
             vdaf.test_vec_encode_input_share(input_shares[1]),
-            cast(bytes, leader_state.outbound),  # XX cast needed?
+            leader_state.outbound,
         )
         assert isinstance(helper_state, FinishedWithOutbound)
 

--- a/poc/vdaf_poc/vdaf_ping_pong.py
+++ b/poc/vdaf_poc/vdaf_ping_pong.py
@@ -150,15 +150,15 @@ class PingPong(
             return Rejected()
 
     def ping_pong_helper_init(
-            self,
-            vdaf_verify_key: bytes,
-            ctx: bytes,
-            agg_param: bytes,
-            nonce: bytes,
-            public_share: bytes,
-            input_share: bytes,
-            inbound: bytes, # encoded ping pong Message
-        ) -> Continued | FinishedWithOutbound | Rejected:
+        self,
+        vdaf_verify_key: bytes,
+        ctx: bytes,
+        agg_param: bytes,
+        nonce: bytes,
+        public_share: bytes,
+        input_share: bytes,
+        inbound: bytes,  # encoded ping pong Message
+    ) -> Continued | FinishedWithOutbound | Rejected:
         """
         Called by the Helper in response to the Leader's initial
         message.
@@ -224,7 +224,7 @@ class PingPong(
         ctx: bytes,
         agg_param: bytes,
         state: Continued,
-        inbound: bytes,
+        inbound: bytes,  # encoded ping pong Message
     ) -> State:
         """
         Called by the Leader to start the next step of ping-ponging.
@@ -238,7 +238,7 @@ class PingPong(
         ctx: bytes,
         agg_param: bytes,
         state: Continued,
-        inbound: bytes, # encoded ping pong Message
+        inbound: bytes,  # encoded ping pong Message
     ) -> State:
         try:
             prep_round = state.prep_round
@@ -287,7 +287,7 @@ class PingPong(
         ctx: bytes,
         agg_param: bytes,
         state: Continued,
-        inbound: bytes, # encoded ping pong Message
+        inbound: bytes,  # encoded ping pong Message
     ) -> State:
         """Called by the Helper to continue ping-ponging."""
         return self.ping_pong_continued(

--- a/poc/vdaf_poc/vdaf_ping_pong.py
+++ b/poc/vdaf_poc/vdaf_ping_pong.py
@@ -200,7 +200,7 @@ class PingPong(
             agg_param: AggParam,
             prep_shares: list[PrepShare],
             prep_state: PrepState,
-            prep_round: int) -> State:
+            prep_round: int) -> Continued | FinishedWithOutbound:
         prep_msg = self.prep_shares_to_prep(ctx,
                                             agg_param,
                                             prep_shares)


### PR DESCRIPTION
This adds one more commit on top of the changes in #543 that I think make the API easier to use, in particular by making illegal states impossible to represent, which I believe is the overall goal here. I've left remarks throughout the diff to highlight important changes and the motivation.

I also haven't yet reflected this proposed change in the actual protocol text. It's only in the Python `poc` for now, so we can discuss whether we like it. Based on the consensus we reach, I can fix up the protocol text accordingly.