### PR TITLE
Add test vector tests

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1729,7 +1729,7 @@ def ping_pong_leader_init(
             prep_state, 0,
             encode(0, encoded_prep_share),  # initialize
         )
-    except:
+    except Exception:
         return Rejected()
 ~~~
 
@@ -1787,7 +1787,7 @@ def ping_pong_helper_init(
             prep_state,
             0,
         )
-    except:
+    except Exception:
         return Rejected()
 ~~~
 
@@ -1894,7 +1894,7 @@ def ping_pong_continued(
             return Finished(out)
         else:
             return Rejected()
-    except:
+    except Exception:
         return Rejected()
 ~~~
 

--- a/poc/gen_test_vec.py
+++ b/poc/gen_test_vec.py
@@ -51,7 +51,7 @@ def gen_test_vec_for_idpf(idpf: Idpf,
         'beta_leaf': printable_beta_leaf,
         'ctx': ctx.hex(),
         'nonce': nonce.hex(),
-        'public_share': idpf.test_vec_encode_public_share(public_share).hex(),
+        'public_share': idpf.encode_public_share(public_share).hex(),
         'keys': printable_keys,
     }
 
@@ -300,19 +300,19 @@ def gen_prio3_negative_test_vec(test_vec_path: str) -> None:
             'measurement': None,
             'rand': rand.hex(),
             'nonce': nonce.hex(),
-            'public_share': prio3histogram.test_vec_encode_public_share(
+            'public_share': prio3histogram.encode_public_share(
                 public_share,
             ).hex(),
             'input_shares': [
-                prio3histogram.test_vec_encode_input_share(
+                prio3histogram.encode_input_share(
                     input_share_0,
                 ).hex(),
-                prio3histogram.test_vec_encode_input_share(
+                prio3histogram.encode_input_share(
                     input_share_1,
                 ).hex(),
             ],
             'prep_shares': [[
-                prio3histogram.test_vec_encode_prep_share(prep_share_0).hex(),
+                prio3histogram.encode_prep_share(prep_share_0).hex(),
             ]],
             'prep_messages': [
                 bad_prep_msg.hex(),
@@ -406,14 +406,14 @@ def _prio3_prep_shares_to_prep_failure(
             'measurement': None,
             'rand': rand.hex(),
             'nonce': nonce.hex(),
-            'public_share': vdaf.test_vec_encode_public_share(public_share).hex(),
+            'public_share': vdaf.encode_public_share(public_share).hex(),
             'input_shares': [
-                vdaf.test_vec_encode_input_share(input_share_0).hex(),
-                vdaf.test_vec_encode_input_share(input_share_1).hex(),
+                vdaf.encode_input_share(input_share_0).hex(),
+                vdaf.encode_input_share(input_share_1).hex(),
             ],
             'prep_shares': [[
-                vdaf.test_vec_encode_prep_share(prep_share_0).hex(),
-                vdaf.test_vec_encode_prep_share(prep_share_1).hex(),
+                vdaf.encode_prep_share(prep_share_0).hex(),
+                vdaf.encode_prep_share(prep_share_1).hex(),
             ]],
             'prep_messages': [],
             'out_shares': [],
@@ -558,25 +558,25 @@ def gen_poplar1_negative_test_vec(test_vec_path: str) -> None:
             'measurement': None,
             'rand': rand.hex(),
             'nonce': nonce.hex(),
-            'public_share': vdaf.test_vec_encode_public_share(public_share).hex(),
+            'public_share': vdaf.encode_public_share(public_share).hex(),
             'input_shares': [
-                vdaf.test_vec_encode_input_share(bad_input_share_0).hex(),
-                vdaf.test_vec_encode_input_share(input_share_1).hex(),
+                vdaf.encode_input_share(bad_input_share_0).hex(),
+                vdaf.encode_input_share(input_share_1).hex(),
             ],
             'prep_shares': [
                 [
-                    vdaf.test_vec_encode_prep_share(prep_share_r0_a0).hex(),
-                    vdaf.test_vec_encode_prep_share(prep_share_r0_a1).hex(),
+                    vdaf.encode_prep_share(prep_share_r0_a0).hex(),
+                    vdaf.encode_prep_share(prep_share_r0_a1).hex(),
                 ],
                 [
-                    vdaf.test_vec_encode_prep_share(
+                    vdaf.encode_prep_share(
                         cast(FieldVec, prep_share_r1_a0)).hex(),
-                    vdaf.test_vec_encode_prep_share(
+                    vdaf.encode_prep_share(
                         cast(FieldVec, prep_share_r1_a1)).hex(),
                 ],
             ],
             'prep_messages': [
-                vdaf.test_vec_encode_prep_msg(prep_msg).hex(),
+                vdaf.encode_prep_msg(prep_msg).hex(),
             ],
             'out_shares': [],
         }],

--- a/poc/tests/test_test_vectors.py
+++ b/poc/tests/test_test_vectors.py
@@ -1,0 +1,805 @@
+import json
+import os.path
+import unittest
+from typing import Generic, Optional, TypeVar, cast
+
+from vdaf_poc.field import Field64, NttField
+from vdaf_poc.test_utils import VdafTestVectorDict
+from vdaf_poc.vdaf import Vdaf
+from vdaf_poc.vdaf_poplar1 import Poplar1
+from vdaf_poc.vdaf_prio3 import (Prio3Count, Prio3Histogram,
+                                 Prio3MultihotCountVec, Prio3Sum, Prio3SumVec,
+                                 Prio3SumVecWithMultiproof)
+
+Measurement = TypeVar("Measurement")
+AggParam = TypeVar("AggParam")
+PublicShare = TypeVar("PublicShare")
+InputShare = TypeVar("InputShare")
+OutShare = TypeVar("OutShare")
+AggShare = TypeVar("AggShare")
+AggResult = TypeVar("AggResult")
+PrepState = TypeVar("PrepState")
+PrepShare = TypeVar("PrepShare")
+PrepMessage = TypeVar("PrepMessage")
+F = TypeVar("F", bound=NttField)
+
+
+class TestVdafTestVector(unittest.TestCase, Generic[Measurement, AggResult]):
+    def check_test_vector(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            test_vector: VdafTestVectorDict[Measurement, AggResult]) -> None:
+        # Prepare states are indexed by the report index, aggregator ID, and
+        # round.
+        prep_states: list[list[dict[int, PrepState]]] = [
+            [{} for _ in range(vdaf.SHARES)]
+            for _ in test_vector["prep"]
+        ]
+
+        for operation in test_vector["operations"]:
+            if operation["operation"] == "shard":
+                report_index = operation["report_index"]
+                prep = test_vector["prep"][report_index]
+                if operation["success"]:
+                    self.check_shard_success(
+                        vdaf,
+                        bytes.fromhex(test_vector["ctx"]),
+                        prep["measurement"],
+                        bytes.fromhex(prep["nonce"]),
+                        bytes.fromhex(prep["rand"]),
+                        bytes.fromhex(prep["public_share"]),
+                        [
+                            bytes.fromhex(input_share)
+                            for input_share in prep["input_shares"]
+                        ],
+                    )
+                else:
+                    self.check_shard_failure(
+                        vdaf,
+                        bytes.fromhex(test_vector["ctx"]),
+                        prep["measurement"],
+                        bytes.fromhex(prep["nonce"]),
+                        bytes.fromhex(prep["rand"]),
+                    )
+            elif operation["operation"] == "prep_init":
+                report_index = operation["report_index"]
+                prep = test_vector["prep"][report_index]
+                aggregator_id = operation["aggregator_id"]
+                if operation["success"]:
+                    new_prep_state = self.check_prep_init_success(
+                        vdaf,
+                        bytes.fromhex(test_vector["verify_key"]),
+                        bytes.fromhex(test_vector["ctx"]),
+                        aggregator_id,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        bytes.fromhex(prep["nonce"]),
+                        bytes.fromhex(prep["public_share"]),
+                        bytes.fromhex(prep["input_shares"][aggregator_id]),
+                        bytes.fromhex(prep["prep_shares"][0][aggregator_id]),
+                    )
+                    prep_states[report_index][aggregator_id][0] = cast(
+                        PrepState,
+                        new_prep_state,
+                    )
+                else:
+                    self.check_prep_init_failure(
+                        vdaf,
+                        bytes.fromhex(test_vector["verify_key"]),
+                        bytes.fromhex(test_vector["ctx"]),
+                        aggregator_id,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        bytes.fromhex(prep["nonce"]),
+                        bytes.fromhex(prep["public_share"]),
+                        bytes.fromhex(prep["input_shares"][aggregator_id]),
+                    )
+            elif operation["operation"] == "prep_shares_to_prep":
+                report_index = operation["report_index"]
+                prep = test_vector["prep"][report_index]
+                round = operation["round"]
+                if operation["success"]:
+                    self.check_prep_shares_to_prep_success(
+                        vdaf,
+                        bytes.fromhex(test_vector["ctx"]),
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            prep_states[report_index][i][round]
+                            for i in range(vdaf.SHARES)
+                        ],
+                        [
+                            bytes.fromhex(prep_share)
+                            for prep_share in prep["prep_shares"][round]
+                        ],
+                        bytes.fromhex(prep["prep_messages"][round]),
+                    )
+                else:
+                    self.check_prep_shares_to_prep_failure(
+                        vdaf,
+                        bytes.fromhex(test_vector["ctx"]),
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            prep_states[report_index][i][round]
+                            for i in range(vdaf.SHARES)
+                        ],
+                        [
+                            bytes.fromhex(prep_share)
+                            for prep_share in prep["prep_shares"][round]
+                        ],
+                    )
+            elif operation["operation"] == "prep_next":
+                report_index = operation["report_index"]
+                prep = test_vector["prep"][report_index]
+                aggregator_id = operation["aggregator_id"]
+                round = operation["round"]
+                ctx = bytes.fromhex(test_vector["ctx"])
+                prep_state = prep_states[report_index][aggregator_id][round - 1]
+                prep_msg = bytes.fromhex(prep["prep_messages"][round - 1])
+                if operation["success"]:
+                    if round < vdaf.ROUNDS:
+                        result = self.check_prep_next_success(
+                            vdaf,
+                            ctx,
+                            round,
+                            prep_state,
+                            prep_msg,
+                            bytes.fromhex(
+                                prep["prep_shares"][round][aggregator_id],
+                            ),
+                            b"",
+                        )
+                        prep_states[report_index][aggregator_id][round] = cast(
+                            PrepState,
+                            result,
+                        )
+                    else:
+                        self.check_prep_next_success(
+                            vdaf,
+                            ctx,
+                            round,
+                            prep_state,
+                            prep_msg,
+                            b"",
+                            bytes.fromhex(prep["out_shares"][aggregator_id]),
+                        )
+                else:
+                    self.check_prep_next_failure(
+                        vdaf,
+                        ctx,
+                        round,
+                        prep_state,
+                        prep_msg,
+                    )
+            elif operation["operation"] == "aggregate":
+                aggregator_id = operation["aggregator_id"]
+                if operation["success"]:
+                    self.check_aggregate_success(
+                        vdaf,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            bytes.fromhex(
+                                prep["out_shares"][aggregator_id],
+                            )
+                            for prep in test_vector["prep"]
+                        ],
+                        bytes.fromhex(
+                            test_vector["agg_shares"][aggregator_id],
+                        ),
+                    )
+                else:
+                    self.check_aggregate_failure(
+                        vdaf,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            bytes.fromhex(
+                                prep["out_shares"][aggregator_id],
+                            )
+                            for prep in test_vector["prep"]
+                        ],
+                    )
+            elif operation["operation"] == "unshard":
+                if operation["success"]:
+                    self.check_unshard_success(
+                        vdaf,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            bytes.fromhex(agg_share)
+                            for agg_share in test_vector["agg_shares"]
+                        ],
+                        len(test_vector["prep"]),
+                        cast(AggResult, test_vector["agg_result"]),
+                    )
+                else:
+                    self.check_unshard_failure(
+                        vdaf,
+                        bytes.fromhex(test_vector["agg_param"]),
+                        [
+                            bytes.fromhex(agg_share)
+                            for agg_share in test_vector["agg_shares"]
+                        ],
+                        len(test_vector["prep"]),
+                    )
+            else:
+                raise Exception(
+                    f"unexpected operation: {operation["operation"]}",
+                )
+
+    def check_shard_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            measurement: Measurement,
+            nonce: bytes,
+            rand: bytes,
+            expected_public_share: bytes,
+            expected_input_shares: list[bytes]) -> None:
+        public_share, input_shares = vdaf.shard(
+            ctx,
+            measurement,
+            nonce,
+            rand,
+        )
+        encoded_public_share = vdaf.encode_public_share(
+            public_share,
+        )
+        self.assertEqual(encoded_public_share, expected_public_share)
+        self.assertEqual(len(input_shares), len(expected_input_shares))
+        for input_share, expected_input_share in zip(
+                input_shares, expected_input_shares):
+            encoded_input_share = vdaf.encode_input_share(
+                input_share,
+            )
+            self.assertEqual(encoded_input_share, expected_input_share)
+
+    def check_shard_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            measurement: Measurement,
+            nonce: bytes,
+            rand: bytes) -> None:
+        self.assertRaises(
+            Exception,
+            lambda: vdaf.shard(ctx, measurement, nonce, rand),
+        )
+
+    def check_prep_init_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            verify_key: bytes,
+            ctx: bytes,
+            aggregator_id: int,
+            agg_param_bytes: bytes,
+            nonce: bytes,
+            public_share_bytes: bytes,
+            input_share_bytes: bytes,
+            expected_prep_share: bytes) -> PrepState:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        public_share = vdaf.decode_public_share(public_share_bytes)
+        input_share = vdaf.decode_input_share(
+            aggregator_id,
+            input_share_bytes,
+        )
+        prep_state, prep_share = vdaf.prep_init(
+            verify_key,
+            ctx,
+            aggregator_id,
+            agg_param,
+            nonce,
+            public_share,
+            input_share,
+        )
+        encoded_prep_share = vdaf.encode_prep_share(prep_share)
+        self.assertEqual(encoded_prep_share, expected_prep_share)
+        return prep_state
+
+    def check_prep_init_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            verify_key: bytes,
+            ctx: bytes,
+            aggregator_id: int,
+            agg_param_bytes: bytes,
+            nonce: bytes,
+            public_share_bytes: bytes,
+            input_share_bytes: bytes) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        public_share = vdaf.decode_public_share(public_share_bytes)
+        input_share = vdaf.decode_input_share(
+            aggregator_id,
+            input_share_bytes,
+        )
+        self.assertRaises(
+            Exception,
+            lambda: vdaf.prep_init(
+                verify_key,
+                ctx,
+                aggregator_id,
+                agg_param,
+                nonce,
+                public_share,
+                input_share,
+            ),
+        )
+
+    def check_prep_shares_to_prep_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            agg_param_bytes: bytes,
+            prep_states: list[PrepState],
+            prep_shares_bytes: list[bytes],
+            expected_prep_msg: bytes) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        prep_shares = [
+            vdaf.decode_prep_share(prep_state, prep_share_bytes)
+            for prep_state, prep_share_bytes in zip(
+                prep_states,
+                prep_shares_bytes,
+            )
+        ]
+        prep_msg = vdaf.prep_shares_to_prep(
+            ctx,
+            agg_param,
+            prep_shares,
+        )
+        encoded_prep_msg = vdaf.encode_prep_msg(prep_msg)
+        self.assertEqual(encoded_prep_msg, expected_prep_msg)
+
+    def check_prep_shares_to_prep_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            agg_param_bytes: bytes,
+            prep_states: list[PrepState],
+            prep_shares_bytes: list[bytes]) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        prep_shares = [
+            vdaf.decode_prep_share(prep_state, prep_share_bytes)
+            for prep_state, prep_share_bytes in zip(
+                prep_states,
+                prep_shares_bytes,
+            )
+        ]
+        self.assertRaises(
+            Exception,
+            lambda: vdaf.prep_shares_to_prep(
+                ctx,
+                agg_param,
+                prep_shares,
+            ),
+        )
+
+    def check_prep_next_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            round: int,
+            prep_state: PrepState,
+            prep_msg_bytes: bytes,
+            expected_prep_share: bytes,
+            expected_out_share: bytes) -> Optional[PrepState]:
+        prep_msg = vdaf.decode_prep_msg(prep_state, prep_msg_bytes)
+        result = vdaf.prep_next(
+            ctx,
+            prep_state,
+            prep_msg,
+        )
+        if round < vdaf.ROUNDS:
+            assert isinstance(result, tuple)
+            next_prep_state, prep_share = result
+            encoded_prep_share = vdaf.encode_prep_share(
+                prep_share,
+            )
+            self.assertEqual(encoded_prep_share, expected_prep_share)
+            return next_prep_state
+        else:
+            out_share = cast(OutShare, result)
+            encoded_out_share = vdaf.encode_out_share(out_share)
+            self.assertEqual(encoded_out_share, expected_out_share)
+            return None
+
+    def check_prep_next_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            ctx: bytes,
+            round: int,
+            prep_state: PrepState,
+            prep_msg_bytes: bytes) -> None:
+        prep_msg = vdaf.decode_prep_msg(prep_state, prep_msg_bytes)
+        self.assertRaises(
+            Exception,
+            lambda: vdaf.prep_next(
+                ctx,
+                prep_state,
+                prep_msg,
+            )
+        )
+
+    def check_aggregate_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            agg_param_bytes: bytes,
+            out_shares_bytes: list[bytes],
+            expected_agg_share: bytes) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        out_shares = [
+            vdaf.decode_out_share(agg_param, out_share_bytes)
+            for out_share_bytes in out_shares_bytes
+        ]
+        agg_share = vdaf.agg_init(agg_param)
+        for out_share in out_shares:
+            agg_share = vdaf.agg_update(agg_param, agg_share, out_share)
+        encoded_agg_share = vdaf.encode_agg_share(agg_share)
+        self.assertEqual(encoded_agg_share, expected_agg_share)
+
+    def check_aggregate_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            agg_param_bytes: bytes,
+            out_shares_bytes: list[bytes]) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        out_shares = [
+            vdaf.decode_out_share(agg_param, out_share_bytes)
+            for out_share_bytes in out_shares_bytes
+        ]
+
+        def aggregate() -> AggShare:
+            agg_share = vdaf.agg_init(agg_param)
+            for out_share in out_shares:
+                agg_share = vdaf.agg_update(agg_param, agg_share, out_share)
+            return agg_share
+
+        self.assertRaises(Exception, aggregate)
+
+    def check_unshard_success(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            agg_param_bytes: bytes,
+            agg_shares_bytes: list[bytes],
+            num_measurements: int,
+            expected_agg_result: AggResult) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        agg_shares = [
+            vdaf.decode_agg_share(agg_param, agg_share_bytes)
+            for agg_share_bytes in agg_shares_bytes
+        ]
+        agg_result = vdaf.unshard(agg_param, agg_shares, num_measurements)
+        self.assertEqual(agg_result, expected_agg_result)
+
+    def check_unshard_failure(
+            self,
+            vdaf: Vdaf[
+                Measurement,
+                AggParam,
+                PublicShare,
+                InputShare,
+                OutShare,
+                AggShare,
+                AggResult,
+                PrepState,
+                PrepShare,
+                PrepMessage,
+            ],
+            agg_param_bytes: bytes,
+            agg_shares_bytes: list[bytes],
+            num_measurements: int) -> None:
+        agg_param = vdaf.decode_agg_param(agg_param_bytes)
+        agg_shares = [
+            vdaf.decode_agg_share(agg_param, agg_share_bytes)
+            for agg_share_bytes in agg_shares_bytes
+        ]
+        self.assertRaises(
+            Exception,
+            lambda: vdaf.unshard(agg_param, agg_shares, num_measurements),
+        )
+
+    def load_test_vector(self, filename: str) -> VdafTestVectorDict[Measurement, AggResult]:
+        path = os.path.join("..", "test_vec", "vdaf", filename)
+        with open(path, "rb") as f:
+            doc = json.load(f)
+        assert "operations" in doc
+        assert "shares" in doc
+        assert "verify_key" in doc
+        assert "agg_param" in doc
+        assert "ctx" in doc
+        assert "prep" in doc
+        assert "agg_shares" in doc
+        assert "agg_result" in doc
+        return doc
+
+
+class TestPrio3CountTestVector(TestVdafTestVector[int, int]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3Count(test_vector["shares"])
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3Count_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3Count_1.json")
+
+    def test_2(self) -> None:
+        self.run_test("Prio3Count_2.json")
+
+    def test_bad_meas_share(self) -> None:
+        self.run_test("Prio3Count_bad_meas_share.json")
+
+    def test_bad_wire_seed(self) -> None:
+        self.run_test("Prio3Count_bad_wire_seed.json")
+
+    def test_bad_gadget_poly(self) -> None:
+        self.run_test("Prio3Count_bad_gadget_poly.json")
+
+    def test_bad_helper_seed(self) -> None:
+        self.run_test("Prio3Count_bad_helper_seed.json")
+
+
+class TestPrio3SumTestVector(TestVdafTestVector[int, int]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3Sum(
+            test_vector["shares"],
+            cast(dict, test_vector)["max_measurement"],
+        )
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3Sum_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3Sum_1.json")
+
+    def test_2(self) -> None:
+        self.run_test("Prio3Sum_2.json")
+
+
+class TestPrio3SumVecTestVector(TestVdafTestVector[list[int], list[int]]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3SumVec(
+            test_vector["shares"],
+            cast(dict, test_vector)["length"],
+            cast(dict, test_vector)["bits"],
+            cast(dict, test_vector)["chunk_length"],
+        )
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3SumVec_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3SumVec_1.json")
+
+
+class TestPrio3SumVecWithMultiproofTestVector(TestVdafTestVector[list[int], list[int]]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3SumVecWithMultiproof(
+            test_vector["shares"],
+            Field64,
+            3,
+            cast(dict, test_vector)["length"],
+            cast(dict, test_vector)["bits"],
+            cast(dict, test_vector)["chunk_length"],
+        )
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3SumVecWithMultiproof_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3SumVecWithMultiproof_1.json")
+
+
+class TestPrio3HistogramTestVector(TestVdafTestVector[int, list[int]]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3Histogram(
+            test_vector["shares"],
+            cast(dict, test_vector)["length"],
+            cast(dict, test_vector)["chunk_length"],
+        )
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3Histogram_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3Histogram_1.json")
+
+    def test_2(self) -> None:
+        self.run_test("Prio3Histogram_2.json")
+
+    def test_bad_public_share(self) -> None:
+        self.run_test("Prio3Histogram_bad_public_share.json")
+
+    def test_bad_leader_jr_blind(self) -> None:
+        self.run_test("Prio3Histogram_bad_leader_jr_blind.json")
+
+    def test_bad_helper_jr_blind(self) -> None:
+        self.run_test("Prio3Histogram_bad_helper_jr_blind.json")
+
+    def test_bad_prep_msg(self) -> None:
+        self.run_test("Prio3Histogram_bad_prep_msg.json")
+
+
+class TestPrio3MultihotCountVecTestVector(TestVdafTestVector[list[bool], list[int]]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3MultihotCountVec(
+            test_vector["shares"],
+            cast(dict, test_vector)["length"],
+            cast(dict, test_vector)["max_weight"],
+            cast(dict, test_vector)["chunk_length"],
+        )
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3MultihotCountVec_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Prio3MultihotCountVec_1.json")
+
+    def test_2(self) -> None:
+        self.run_test("Prio3MultihotCountVec_2.json")
+
+
+class TestPoplar1TestVector(TestVdafTestVector[tuple[bool, ...], list[int]]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Poplar1(cast(dict, test_vector)["bits"])
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Poplar1_0.json")
+
+    def test_1(self) -> None:
+        self.run_test("Poplar1_1.json")
+
+    def test_2(self) -> None:
+        self.run_test("Poplar1_2.json")
+
+    def test_3(self) -> None:
+        self.run_test("Poplar1_3.json")
+
+    def test_4(self) -> None:
+        self.run_test("Poplar1_4.json")
+
+    def test_5(self) -> None:
+        self.run_test("Poplar1_5.json")
+
+    def test_bad_corr_inner(self) -> None:
+        self.run_test("Poplar1_bad_corr_inner.json")

--- a/poc/tests/test_vdaf_ping_pong.py
+++ b/poc/tests/test_vdaf_ping_pong.py
@@ -111,30 +111,22 @@ class PingPongTester(
                 _num_measurements: int) -> int:
         return agg_param * sum(agg_shares) // self.SHARES
 
-    def test_vec_encode_input_share(self, input_share: int) -> bytes:
+    def encode_input_share(self, input_share: int) -> bytes:
         return to_be_bytes(input_share, 8)
 
-    def test_vec_encode_public_share(self, public_share: str) -> bytes:
+    def decode_input_share(self, _agg_id: int, encoded: bytes) -> int:
+        return from_be_bytes(encoded)
+
+    def encode_public_share(self, public_share: str) -> bytes:
         return public_share.encode('utf-8')
-
-    def test_vec_encode_agg_share(self, agg_share: int) -> bytes:
-        return to_be_bytes(agg_share, 8)
-
-    def test_vec_encode_prep_share(self, prep_share: str) -> bytes:
-        return self.encode_prep_share(prep_share)
-
-    def test_vec_encode_prep_msg(self, prep_msg: str) -> bytes:
-        return self.encode_prep_msg(prep_msg)
-
-    def test_vec_encode_out_share(self, out_share: int) -> bytes:
-        return to_be_bytes(out_share, 8)
-
-    # `PingPong`
 
     def decode_public_share(self, encoded: bytes) -> str:
         return encoded.decode('utf-8')
 
-    def decode_input_share(self, _agg_id: int, encoded: bytes) -> int:
+    def encode_agg_share(self, agg_share: int) -> bytes:
+        return to_be_bytes(agg_share, 8)
+
+    def decode_agg_share(self, _agg_param: int, encoded: bytes) -> int:
         return from_be_bytes(encoded)
 
     def encode_prep_share(self, prep_share: str) -> bytes:
@@ -152,6 +144,12 @@ class PingPongTester(
                         _prep_state: tuple[int, int],
                         encoded: bytes) -> str:
         return encoded.decode('utf-8')
+
+    def encode_out_share(self, out_share: int) -> bytes:
+        return to_be_bytes(out_share, 8)
+
+    def decode_out_share(self, _agg_param: int, encoded: bytes) -> int:
+        return from_be_bytes(encoded)
 
     def decode_agg_param(self, encoded: bytes) -> int:
         return from_be_bytes(encoded)
@@ -194,8 +192,8 @@ class TestPingPong(unittest.TestCase):
             ctx,
             vdaf.encode_agg_param(agg_param),
             nonce,
-            vdaf.test_vec_encode_public_share(public_share),
-            vdaf.test_vec_encode_input_share(input_shares[0]),
+            vdaf.encode_public_share(public_share),
+            vdaf.encode_input_share(input_shares[0]),
         )
         assert isinstance(leader_init_state, Continued)
         self.assertEqual(leader_init_state.prep_round, 0)
@@ -205,8 +203,8 @@ class TestPingPong(unittest.TestCase):
             ctx,
             vdaf.encode_agg_param(agg_param),
             nonce,
-            vdaf.test_vec_encode_public_share(public_share),
-            vdaf.test_vec_encode_input_share(input_shares[1]),
+            vdaf.encode_public_share(public_share),
+            vdaf.encode_input_share(input_shares[1]),
             leader_init_state.outbound,
         )
         assert isinstance(helper_state, FinishedWithOutbound)
@@ -245,8 +243,8 @@ class TestPingPong(unittest.TestCase):
                 ctx,
                 vdaf.encode_agg_param(agg_param),
                 nonce,
-                vdaf.test_vec_encode_public_share(public_share),
-                vdaf.test_vec_encode_input_share(input_shares[0]),
+                vdaf.encode_public_share(public_share),
+                vdaf.encode_input_share(input_shares[0]),
             )
             assert isinstance(leader_state, Continued)
             self.assertEqual(leader_state.prep_round, 0)
@@ -259,8 +257,8 @@ class TestPingPong(unittest.TestCase):
                         ctx,
                         vdaf.encode_agg_param(agg_param),
                         nonce,
-                        vdaf.test_vec_encode_public_share(public_share),
-                        vdaf.test_vec_encode_input_share(input_shares[1]),
+                        vdaf.encode_public_share(public_share),
+                        vdaf.encode_input_share(input_shares[1]),
                         leader_state.outbound,
                     )
                 else:

--- a/poc/vdaf_poc/common.py
+++ b/poc/vdaf_poc/common.py
@@ -136,6 +136,7 @@ def front(
     Split list `vec` in two and return the front and remainder as a tuple. The
     length of the front is `length`.
     """
+    assert length <= len(vec)
     return (vec[:length], vec[length:])
 
 

--- a/poc/vdaf_poc/idpf.py
+++ b/poc/vdaf_poc/idpf.py
@@ -149,5 +149,5 @@ class Idpf(Generic[FieldInner, FieldLeaf, PublicShare], metaclass=ABCMeta):
         return x == y[:level + 1]
 
     @abstractmethod
-    def test_vec_encode_public_share(self, public_share: PublicShare) -> bytes:
+    def encode_public_share(self, public_share: PublicShare) -> bytes:
         pass

--- a/poc/vdaf_poc/idpf_bbcggi21.py
+++ b/poc/vdaf_poc/idpf_bbcggi21.py
@@ -352,9 +352,6 @@ class IdpfBBCGGI21(Idpf[Field64, Field255, list[CorrectionWord]]):
             raise ValueError('trailing bytes')
         return list(zip(seeds, ctrl, payloads))
 
-    def test_vec_encode_public_share(self, public_share: list[CorrectionWord]) -> bytes:
-        return self.encode_public_share(public_share)
-
 
 def pack_bits(control_bits: list[bool]) -> bytes:
     packed_len = (len(control_bits) + 7) // 8

--- a/poc/vdaf_poc/test_utils.py
+++ b/poc/vdaf_poc/test_utils.py
@@ -148,7 +148,7 @@ class VdafPrepTestVectorDict(Generic[Measurement], TypedDict):
     out_shares: list[str]
 
 
-class VdafTestVectorDict(Generic[Measurement, AggParam, AggResult], TypedDict):
+class VdafTestVectorDict(Generic[Measurement, AggResult], TypedDict):
     """
     A test vector for evaluation of a VDAF on one or more reports.
 
@@ -213,7 +213,7 @@ def gen_test_vec_for_vdaf(
         measurements: list[Measurement],
         test_vec_instance: int,
         print_test_vec: bool = True) -> \
-        VdafTestVectorDict[Measurement, AggParam, AggResult]:
+        VdafTestVectorDict[Measurement, AggResult]:
     """
     Generate test vectors for successful evaluation of a VDAF.
     """
@@ -223,7 +223,7 @@ def gen_test_vec_for_vdaf(
     verify_key = test_vec_gen_rand(vdaf.VERIFY_KEY_SIZE)
     operations: list[VdafTestVectorOperationDict] = []
 
-    test_vec: VdafTestVectorDict[Measurement, AggParam, AggResult] = {
+    test_vec: VdafTestVectorDict[Measurement, AggResult] = {
         'operations': operations,
         'shares': vdaf.SHARES,
         'verify_key': verify_key.hex(),
@@ -252,7 +252,7 @@ def gen_test_vec_for_vdaf(
             'success': True,
         })
 
-        pub_share_hex = vdaf.test_vec_encode_public_share(public_share).hex()
+        pub_share_hex = vdaf.encode_public_share(public_share).hex()
         prep_test_vec: VdafPrepTestVectorDict[Measurement] = {
             'measurement': measurement,
             'nonce': nonce.hex(),
@@ -265,7 +265,7 @@ def gen_test_vec_for_vdaf(
         }
         for input_share in input_shares:
             prep_test_vec['input_shares'].append(
-                vdaf.test_vec_encode_input_share(input_share).hex())
+                vdaf.encode_input_share(input_share).hex())
 
         # Each Aggregator initializes its preparation state.
         prep_states = []
@@ -287,7 +287,7 @@ def gen_test_vec_for_vdaf(
 
         for prep_share in outbound_prep_shares:
             prep_test_vec['prep_shares'][0].append(
-                vdaf.test_vec_encode_prep_share(prep_share).hex())
+                vdaf.encode_prep_share(prep_share).hex())
 
         # Aggregators recover their output shares.
         for i in range(vdaf.ROUNDS - 1):
@@ -295,7 +295,7 @@ def gen_test_vec_for_vdaf(
                                                 agg_param,
                                                 outbound_prep_shares)
             prep_test_vec['prep_messages'].append(
-                vdaf.test_vec_encode_prep_msg(prep_msg).hex())
+                vdaf.encode_prep_msg(prep_msg).hex())
             operations.append({
                 'operation': 'prep_shares_to_prep',
                 'round': i,
@@ -310,7 +310,7 @@ def gen_test_vec_for_vdaf(
                 (prep_states[j], prep_share) = out
                 outbound_prep_shares.append(prep_share)
                 prep_test_vec['prep_shares'][i+1].append(
-                    vdaf.test_vec_encode_prep_share(prep_share).hex()
+                    vdaf.encode_prep_share(prep_share).hex()
                 )
                 operations.append({
                     'operation': 'prep_next',
@@ -326,7 +326,7 @@ def gen_test_vec_for_vdaf(
                                             agg_param,
                                             outbound_prep_shares)
         prep_test_vec['prep_messages'].append(
-            vdaf.test_vec_encode_prep_msg(prep_msg).hex())
+            vdaf.encode_prep_msg(prep_msg).hex())
         operations.append({
             'operation': 'prep_shares_to_prep',
             'round': vdaf.ROUNDS - 1,
@@ -340,7 +340,7 @@ def gen_test_vec_for_vdaf(
             assert not isinstance(out_share, tuple)
             outbound_out_shares.append(out_share)
             prep_test_vec['out_shares'].append(
-                vdaf.test_vec_encode_out_share(out_share).hex()
+                vdaf.encode_out_share(out_share).hex()
             )
             operations.append({
                 'operation': 'prep_next',
@@ -365,7 +365,7 @@ def gen_test_vec_for_vdaf(
             agg_share_j = vdaf.agg_update(agg_param, agg_share_j, out_share)
         agg_shares.append(agg_share_j)
         test_vec['agg_shares'].append(
-            vdaf.test_vec_encode_agg_share(agg_share_j).hex())
+            vdaf.encode_agg_share(agg_share_j).hex())
         operations.append({
             'operation': 'aggregate',
             'aggregator_id': j,
@@ -396,7 +396,7 @@ def gen_test_vec_for_vdaf(
 
 def write_test_vec(
         test_vec_path: str,
-        test_vec: VdafTestVectorDict[Measurement, AggParam, AggResult],
+        test_vec: VdafTestVectorDict[Measurement, AggResult],
         test_vec_name: str,
         test_vec_suffix: str) -> None:
     """
@@ -417,7 +417,7 @@ def pretty_print_vdaf_test_vec(
         vdaf: Vdaf[
             Measurement, AggParam, Any, Any, Any, Any, AggResult, Any, Any, Any
         ],
-        typed_test_vec: VdafTestVectorDict[Measurement, AggParam, AggResult],
+        typed_test_vec: VdafTestVectorDict[Measurement, AggResult],
         type_params: list[str]) -> None:
     test_vec = cast(dict[str, Any], typed_test_vec)
     print('---------- {} ---------------'.format(vdaf.test_vec_name))

--- a/poc/vdaf_poc/vdaf.py
+++ b/poc/vdaf_poc/vdaf.py
@@ -214,6 +214,58 @@ class Vdaf(
     def encode_agg_param(self, agg_param: AggParam) -> bytes:
         pass
 
+    @abstractmethod
+    def decode_agg_param(self, encoded: bytes) -> AggParam:
+        pass
+
+    @abstractmethod
+    def encode_input_share(self, input_share: InputShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_input_share(self, agg_id: int, encoded: bytes) -> InputShare:
+        pass
+
+    @abstractmethod
+    def encode_public_share(self, public_share: PublicShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_public_share(self, encoded: bytes) -> PublicShare:
+        pass
+
+    @abstractmethod
+    def encode_agg_share(self, agg_share: AggShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_agg_share(self, agg_param: AggParam, encoded: bytes) -> AggShare:
+        pass
+
+    @abstractmethod
+    def encode_prep_share(self, prep_share: PrepShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_prep_share(self, prep_state: PrepState, encoded: bytes) -> PrepShare:
+        pass
+
+    @abstractmethod
+    def encode_prep_msg(self, prep_message: PrepMessage) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_prep_msg(self, prep_state: PrepState, encoded: bytes) -> PrepMessage:
+        pass
+
+    @abstractmethod
+    def encode_out_share(self, out_share: OutShare) -> bytes:
+        pass
+
+    @abstractmethod
+    def decode_out_share(self, agg_param: AggParam, encoded: bytes) -> OutShare:
+        pass
+
     # Methods for generating test vectors
 
     def test_vec_set_type_param(self, _test_vec: dict[str, Any]) -> list[str]:
@@ -222,30 +274,6 @@ class Vdaf(
         class. Returns the keys that were set.
         """
         return []
-
-    @abstractmethod
-    def test_vec_encode_input_share(self, input_share: InputShare) -> bytes:
-        pass
-
-    @abstractmethod
-    def test_vec_encode_public_share(self, public_share: PublicShare) -> bytes:
-        pass
-
-    @abstractmethod
-    def test_vec_encode_agg_share(self, agg_share: AggShare) -> bytes:
-        pass
-
-    @abstractmethod
-    def test_vec_encode_prep_share(self, prep_share: PrepShare) -> bytes:
-        pass
-
-    @abstractmethod
-    def test_vec_encode_prep_msg(self, prep_message: PrepMessage) -> bytes:
-        pass
-
-    @abstractmethod
-    def test_vec_encode_out_share(self, out_share: OutShare) -> bytes:
-        pass
 
 
 # NOTE: This function is excerpted in the document, as the figure

--- a/poc/vdaf_poc/vdaf_ping_pong.py
+++ b/poc/vdaf_poc/vdaf_ping_pong.py
@@ -1,6 +1,6 @@
 """Ping-pong topology for VDAFs."""
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from typing import Generic, TypeVar, cast
 
 from vdaf_poc.common import byte, from_be_bytes, front, to_be_bytes
@@ -85,35 +85,6 @@ class PingPong(
             PrepMessage,
         ],
         metaclass=ABCMeta):
-
-    @abstractmethod
-    def decode_public_share(self, encoded: bytes) -> PublicShare:
-        pass
-
-    @abstractmethod
-    def decode_input_share(self, agg_id: int, encoded: bytes) -> InputShare:
-        pass
-
-    @abstractmethod
-    def encode_prep_share(self, prep_share: PrepShare) -> bytes:
-        pass
-
-    @abstractmethod
-    def decode_prep_share(self, prep_state: PrepState, encoded: bytes) -> PrepShare:
-        pass
-
-    @abstractmethod
-    def encode_prep_msg(self, prep_msg: PrepMessage) -> bytes:
-        pass
-
-    @abstractmethod
-    def decode_prep_msg(self, prep_state: PrepState, encoded: bytes) -> PrepMessage:
-        pass
-
-    @abstractmethod
-    def decode_agg_param(self, encoded: bytes) -> AggParam:
-        pass
-
     # NOTE: Methods ping_pong_leader_init(), ping_pong_helper_init(),
     # ping_pong_transition(), ping_pong_leader_continued(),
     # ping_pong_continued(), and ping_pong_helper_continued() are excerpted in

--- a/poc/vdaf_poc/vdaf_ping_pong.py
+++ b/poc/vdaf_poc/vdaf_ping_pong.py
@@ -117,7 +117,7 @@ class PingPong(
                 prep_state, 0,
                 encode(0, encoded_prep_share),  # initialize
             )
-        except:
+        except Exception:
             return Rejected()
 
     def ping_pong_helper_init(
@@ -162,7 +162,7 @@ class PingPong(
                 prep_state,
                 0,
             )
-        except:
+        except Exception:
             return Rejected()
 
     def ping_pong_transition(
@@ -250,7 +250,7 @@ class PingPong(
                 return Finished(out)
             else:
                 return Rejected()
-        except:
+        except Exception:
             return Rejected()
 
     def ping_pong_helper_continued(


### PR DESCRIPTION
This fixes #541. I defined a suite of methods to decode various VDAF messages, and removed the `test_vec_` prefix in some cases from those methods that encoded messages. Each test vector file now has its own unit test, which runs all operations in sequence and compares against the expected results.