### PR TITLE
Faster polynomial evaluation in Lagrange basis from rhizomes paper.

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -159,6 +159,8 @@ informative:
     date: 2021
     target: https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ENPA_White_Paper.pdf
 
+  Faz25: DOI.10.1007/978-3-032-06754-8_16
+
   GI14:
     title: "Distributed Point Functions and Their Applications"
     author:
@@ -3826,9 +3828,13 @@ produce the gadget's output. Then compute the wire polynomials from the
 recorded values.
 
 Next, choose a random point `t` (parsed from the query randomness), evaluate
-each wire polynomial at `t`, and evaluate the gadget polynomial at `t`. The
-results are recorded in the verifier message passed to the decision algorithm,
-where the test is finished.
+each wire polynomial at `t`, and evaluate the gadget polynomial at `t`.
+Note that the wire polynomials are in the value (Lagrange) representation
+by construction. Faster polynomial evaluation in this representation is
+possible by using the algorithm by {{Faz25}} without resorting to
+polynomial interpolation.
+The results are recorded in the verifier message passed to the decision
+algorithm, where the test is finished.
 
 The random point `t` MUST NOT be one of the fixed evaluation points used to
 interpolate the wire polynomials. Otherwise, the verifier message may partially

--- a/poc/vdaf_poc/field.py
+++ b/poc/vdaf_poc/field.py
@@ -245,7 +245,7 @@ def poly_add(field: type[F], p: list[F], q: list[F]) -> list[F]:
 
 
 def poly_eval(field: type[F], p: list[F], eval_at: F) -> F:
-    """Evaluate a polynomial at a point."""
+    """Evaluate a polynomial in the monomial basis at a point."""
     if len(p) == 0:
         return field(0)
 
@@ -256,6 +256,28 @@ def poly_eval(field: type[F], p: list[F], eval_at: F) -> F:
         result += c
 
     return result
+
+
+def poly_eval_lagrange(field: type[F], roots: list[F], polys: list[list[F]], eval_at: F) -> list[F]:
+    """Evaluate polynomials in the Lagrange basis at a point.
+
+       Faster batched evaluation method. Alg. 7 of the Rhizomes paper.
+       https://ia.cr/2025/1727.
+    """
+    N = len(roots)
+    assert N.bit_count() == 1, "N must be a power of two"
+    Np = field(N).inv()
+    l = field(1)
+    u = [p[0] for p in polys]
+    d = roots[0] - eval_at
+    for i in range(1, N):
+        l = l * d
+        d = roots[i] - eval_at
+        t = l * roots[i]
+        for j, p in enumerate(polys):
+            u[j] = u[j]*d + t*p[i]
+
+    return [-uj * Np for uj in u]
 
 
 def poly_interp(field: type[F], xs: list[F], ys: list[F]) -> list[F]:


### PR DESCRIPTION
Introduces the use of (batched) polynomial evaluation directly in Lagrange basis.
It avoid conversions to the monomial basis during FLP.Query.

No wire changes.


Closes #573 

--
Reviewers: 
Still needs to add either a reference to the paper or to fully describe the algorithm in the spec. Let me know the prefered choice.
  
