### PR TITLE
Add test vector for Prio3 with a degree 3 gadget

### DIFF
--- a/poc/gen_test_vec.py
+++ b/poc/gen_test_vec.py
@@ -4,6 +4,7 @@ import json
 import os
 from typing import Any, cast
 
+from tests.test_vdaf_prio3 import Prio3HigherDegree
 from vdaf_poc.common import print_wrapped_line
 from vdaf_poc.field import Field64, Field128
 from vdaf_poc.idpf import FieldVec, Idpf
@@ -776,6 +777,16 @@ def main() -> None:
             [True, True, True, True],
         ],
         2,
+    )
+
+    # Prio3HigherDegree
+    gen_test_vec_for_vdaf(
+        vdaf_test_vec_path,
+        Prio3HigherDegree(2),
+        None,
+        ctx,
+        [2],
+        0,
     )
 
     # Poplar1

--- a/poc/tests/test_test_vectors.py
+++ b/poc/tests/test_test_vectors.py
@@ -3,6 +3,7 @@ import os.path
 import unittest
 from typing import Generic, Optional, TypeVar, cast
 
+from tests.test_vdaf_prio3 import Prio3HigherDegree
 from vdaf_poc.field import Field64, NttField
 from vdaf_poc.test_utils import VdafTestVectorDict
 from vdaf_poc.vdaf import Vdaf
@@ -784,6 +785,16 @@ class TestPrio3MultihotCountVecTestVector(TestVdafTestVector[list[bool], list[in
 
     def test_2(self) -> None:
         self.run_test("Prio3MultihotCountVec_2.json")
+
+
+class TestPrio3HigherDegreeTestVector(TestVdafTestVector[int, int]):
+    def run_test(self, filename: str) -> None:
+        test_vector = self.load_test_vector(filename)
+        vdaf = Prio3HigherDegree(test_vector["shares"])
+        self.check_test_vector(vdaf, test_vector)
+
+    def test_0(self) -> None:
+        self.run_test("Prio3HigherDegree_0.json")
 
 
 class TestPoplar1TestVector(TestVdafTestVector[tuple[bool, ...], list[int]]):

--- a/poc/tests/test_vdaf_prio3.py
+++ b/poc/tests/test_vdaf_prio3.py
@@ -1,7 +1,7 @@
 from typing import TypeVar
 
 from tests.test_flp import FlpTest
-from tests.test_flp_bbcggi19 import TestAverage
+from tests.test_flp_bbcggi19 import HigherDegree, TestAverage
 from vdaf_poc.field import Field64, Field128, NttField
 from vdaf_poc.flp_bbcggi19 import FlpBBCGGI19
 from vdaf_poc.test_utils import TestVdaf
@@ -27,6 +27,22 @@ class Prio3Average(Prio3):
 
     def __init__(self, shares: int, bits: int):
         flp = FlpBBCGGI19(TestAverage(Field128, bits))
+        super().__init__(shares, flp, 1)
+
+
+class Prio3HigherDegree(Prio3):
+    """
+    A Prio3 instantiation for use in tests that incorporates a degree three
+    gadget.
+    """
+    xof = XofTurboShake128
+    ID = 0xFFFFFFFF
+    VERIFY_KEY_SIZE = xof.SEED_SIZE
+
+    test_vec_name = 'Prio3HigherDegree'
+
+    def __init__(self, shares: int):
+        flp = FlpBBCGGI19(HigherDegree())
         super().__init__(shares, flp, 1)
 
 
@@ -183,6 +199,12 @@ class TestPrio3Average(TestVdaf):
         # otherwise.
         self.assertTrue(prio3.is_valid(None, list([])))
         self.assertFalse(prio3.is_valid(None, list([None])))
+
+
+class TestPrio3HigherDegree(TestVdaf):
+    def test(self) -> None:
+        prio3 = Prio3HigherDegree(2)
+        self.run_vdaf_test(prio3, None, [0, 1, 2], 3)
 
 
 class TestPrio3SumVecWithMultiproof(TestVdaf):

--- a/test_vec/vdaf/Prio3HigherDegree_0.json
+++ b/test_vec/vdaf/Prio3HigherDegree_0.json
@@ -1,0 +1,89 @@
+{
+    "agg_param": "",
+    "agg_result": 2,
+    "agg_shares": [
+        "d8e24b90f4a12de6",
+        "2b1db46f0a5ed219"
+    ],
+    "ctx": "736f6d65206170706c69636174696f6e",
+    "operations": [
+        {
+            "operation": "shard",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "verify_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "verify_init",
+            "report_index": 0,
+            "success": true
+        },
+        {
+            "operation": "verifier_shares_to_message",
+            "report_index": 0,
+            "round": 0,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "verify_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "verify_next",
+            "report_index": 0,
+            "round": 1,
+            "success": true
+        },
+        {
+            "aggregator_id": 0,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "aggregator_id": 1,
+            "operation": "aggregate",
+            "success": true
+        },
+        {
+            "operation": "unshard",
+            "success": true
+        }
+    ],
+    "reports": [
+        {
+            "input_shares": [
+                "d8e24b90f4a12de62092a768f2b5b1b19ca765c3f579cd4b7a87c0fb0a124281d722220f54eed0f8b3cb522d8b6c97f7",
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            ],
+            "measurement": 2,
+            "nonce": "000102030405060708090a0b0c0d0e0f",
+            "out_shares": [
+                "d8e24b90f4a12de6",
+                "2b1db46f0a5ed219"
+            ],
+            "public_share": "",
+            "rand": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+            "verifier_messages": [
+                ""
+            ],
+            "verifier_shares": [
+                [
+                    "d722220f54eed0f8817d16866711eabd3b4cdc70a53f6754",
+                    "2addddf0aa112f070c8ed9fef8f68c9f341d1fb454b2551e"
+                ]
+            ]
+        }
+    ],
+    "shares": 2,
+    "verify_key": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+}


### PR DESCRIPTION
This adds one Prio3 test vector for a test-only circuit that uses a degree 3 gadget. This will give us better coverage of edge cases, and ensures flexibility for more complicated circuits defined in the future.

Closes #586.