### PR TITLE
Add missing comma in excerpt

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -3028,7 +3028,7 @@ def verifier_shares_to_message(
     self,
     ctx: bytes,
     _agg_param: None,
-    verifier_shares: list[Prio3VerifierShare[F]]
+    verifier_shares: list[Prio3VerifierShare[F]],
 ) -> Optional[bytes]:
     # Unshard each set of verifier shares into each verifier message.
     verifiers = self.flp.field.zeros(


### PR DESCRIPTION
I went through the document (as of #601) to ensure the code excerpts were up-to-date with the `poc` directory, and I just found this missing comma.