### PR TITLE
Clarify description of FLP consistency checks

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -4059,7 +4059,7 @@ To finish each gadget test, evaluate the gadget on the evaluations of the wire
 polynomials parsed from the verifier message: if the
 encoded measurement and joint randomness used to generate the proof are the
 same as the measurement (share) and joint randomness used to verify the proof,
-then the output of the gadget will be equal to the evaluation of the wire
+then the output of the gadget will be equal to the evaluation of the gadget
 polynomial in the verifier message; otherwise, the
 output will not equal the gadget polynomial evaluation with high probability.
 

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -4022,8 +4022,13 @@ def query(self,
 
         # To test the gadget, we re-compute the wire polynomials and
         # check for consistency with the gadget polynomial provided
-        # by the prover. To start, evaluate the gadget polynomial
-        # and each of the wire polynomials at the random point `t`.
+        # by the prover. Here, we evaluate secret shares of the
+        # gadget polynomial and secret shares of each of the wire
+        # polynomials at the random point `t`. These secret shares
+        # will be combined into polynomial evaluations at `t` when
+        # verifier shares are combined into a verifier message.
+        # Then, the `decide()` procedure will perform nonlinear
+        # computations and the final consistency checks.
         wire_checks = lag.poly_eval_batched(g.wires[:g.ARITY], t)
         gadget_check = lag.poly_eval(g.poly, t)
 
@@ -4050,11 +4055,13 @@ The decision algorithm consumes the verifier message. (Each of the Aggregators
 computes an additive share of the verifier message after the previous step.) The
 verifier message consists of the reduced circuit output and the gadget tests.
 
-To finish each gadget test, evaluate the gadget on the wire checks: if the
+To finish each gadget test, evaluate the gadget on the evaluations of the wire
+polynomials parsed from the verifier message: if the
 encoded measurement and joint randomness used to generate the proof are the
 same as the measurement (share) and joint randomness used to verify the proof,
-then the output of the gadget will be equal to the gadget check; otherwise, the
-output will not equal the gadget check with high probability.
+then the output of the gadget will be equal to the evaluation of the wire
+polynomial in the verifier message; otherwise, the
+output will not equal the gadget polynomial evaluation with high probability.
 
 ~~~ python
 def decide(self, verifier: list[F]) -> bool:
@@ -4063,7 +4070,10 @@ def decide(self, verifier: list[F]) -> bool:
     if v != self.field(0):
         return False
 
-    # Complete each gadget test.
+    # Complete each gadget test. Check if the evaluations of gadget
+    # polynomials are consistent with evaluations of wire polynomials
+    # by evaluating the gadgets on the evaluations of the wire
+    # polynomials.
     for g in self.valid.GADGETS:
         (wire_checks, verifier) = front(g.ARITY, verifier)
         ([gadget_check], verifier) = front(1, verifier)

--- a/poc/vdaf_poc/flp_bbcggi19.py
+++ b/poc/vdaf_poc/flp_bbcggi19.py
@@ -464,8 +464,13 @@ class FlpBBCGGI19(Flp[Measurement, AggResult, F]):
 
             # To test the gadget, we re-compute the wire polynomials and
             # check for consistency with the gadget polynomial provided
-            # by the prover. To start, evaluate the gadget polynomial
-            # and each of the wire polynomials at the random point `t`.
+            # by the prover. Here, we evaluate secret shares of the
+            # gadget polynomial and secret shares of each of the wire
+            # polynomials at the random point `t`. These secret shares
+            # will be combined into polynomial evaluations at `t` when
+            # verifier shares are combined into a verifier message.
+            # Then, the `decide()` procedure will perform nonlinear
+            # computations and the final consistency checks.
             wire_checks = lag.poly_eval_batched(g.wires[:g.ARITY], t)
             gadget_check = lag.poly_eval(g.poly, t)
 
@@ -482,7 +487,10 @@ class FlpBBCGGI19(Flp[Measurement, AggResult, F]):
         if v != self.field(0):
             return False
 
-        # Complete each gadget test.
+        # Complete each gadget test. Check if the evaluations of gadget
+        # polynomials are consistent with evaluations of wire polynomials
+        # by evaluating the gadgets on the evaluations of the wire
+        # polynomials.
         for g in self.valid.GADGETS:
             (wire_checks, verifier) = front(g.ARITY, verifier)
             ([gadget_check], verifier) = front(1, verifier)


### PR DESCRIPTION
This revises the description of how the `query()` and `decide()` parts of the FLP work together, both in the spec text and in reference implementation comments. This gets rid of the terms "wire check" and "gadget check", which were only used here and not properly defined.

Closes #610.