### PR TITLE
Update commit in test vector reference

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -263,8 +263,8 @@ informative:
   TestVectors:
     title: "Test vectors for Prio3 and Poplar1"
     target: "https://github.com/cfrg/draft-irtf-cfrg-vdaf"
-    refcontent: "commit hash 5b7df1d"
-    date: December 2024
+    refcontent: "commit hash 888e4b1"
+    date: December 2025
 
 v3xml2rfc:
   silence:


### PR DESCRIPTION
We're due for an update of the commit we use for test vectors. Per the [log](https://github.com/cfrg/draft-irtf-cfrg-vdaf/commits/main/test_vec), this includes the prep to verify name change, Rhizomes and range check improvements, the VERSION bump, and an additional test vector for Prio3 with a degree 3 gadget.