### PR TITLE
More idnits: Replace RFC8446 with RFC9846

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -1797,7 +1797,7 @@ verification is completed. All told there are `ceil((vdaf.ROUNDS+1)/2)`
 requests sent.
 
 Protocol messages are specified in the presentation language of TLS; see
-{{Section 3 of !RFC8446}}. Each message is structured as follows:
+{{Section 3 of !RFC9846}}. Each message is structured as follows:
 
 ~~~ tls-presentation
 <CODE BEGINS>
@@ -3464,7 +3464,7 @@ def joint_rands(self,
 
 This section defines serialization formats for messages exchanged over the
 network while executing Prio3. Messages are defined in the presentation
-language of TLS as defined in {{Section 3 of !RFC8446}}.
+language of TLS as defined in {{Section 3 of !RFC9846}}.
 
 Let `prio3` denote an instance of `Prio3`. In the remainder, let `S` be an
 alias for `prio3.xof.SEED_SIZE` and `F` as an alias for
@@ -5507,7 +5507,7 @@ def unshard(
 
 This section defines serialization formats for messages exchanged over the
 network while executing `Poplar1`. Messages are defined in the presentation
-language of TLS as defined in {{Section 3 of !RFC8446}}.
+language of TLS as defined in {{Section 3 of !RFC9846}}.
 
 Let `poplar1` be an instance of `Poplar1`. In the remainder let `Fi` be an
 alias for `poplar1.idpf.field_inner.ENCODED_SIZE`, `Fl` as an alias for


### PR DESCRIPTION
I ran idnits version 3 against the RFCXML form of the document to see what else it flagged. I built the XML file with `make versioned/draft-irtf-cfrg-vdaf-21.xml`, and then passed it to the JS-based idnits version 3. It produced the following errors/warnings/comments.

* `INVALID_REFERENCES_NAME`: This is a false positive, see ietf-tools/idnits#227.
* `OBSOLETE_REFERENCE`: I replaced RFC 8446 with RFC 9846. We only reference section 3, and that has barely changed. See https://author-tools.ietf.org/iddiff?url1=rfc8446&url2=rfc9846.
* `LINE_PI`: These processing instruction tags are generated automatically by kramdown-rfc.
* `TEXT_DOC_REF`: These are all false positives due to uses of square brackets inside `<tt>` or `<artwork>` tags. FYI, I found the relevant text by manually converting the paths like `rfc.rfc.middle.section[1].ul[2].li[3].t.tt[1]` to XPath expressions, and evaluating them against the document with `xmllint --xpath 'rfc/middle/section[2]/ul[3]/li[4]/t/tt[2]' versioned/draft-irtf-cfrg-vdaf-21.xml`.
* `NON_ASCII_UTF8`: As before, there are non-ASCII characters in the title and authors list of a couple of the documents we reference. I plan to leave these as-is.