### PR TITLE
Revise consensus-level statement

### DIFF
--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -461,7 +461,10 @@ enumerates security considerations for DAFs and VDAFs in general and the
 Prio3 and Poplar1 constructions in particular.
 
 This document represents the consensus of the Crypto Forum Research Group
-(CFRG).
+(CFRG). It has received review from CFRG participants, including review during
+Research Group Last Call, and an additional review by the CFRG Crypto Review
+Panel. It is also informed by experience from multiple independent
+implementations
 
 ## Change Log
 

--- a/draft-irtf-cfrg-vdaf.md
+++ b/draft-irtf-cfrg-vdaf.md
@@ -463,8 +463,8 @@ Prio3 and Poplar1 constructions in particular.
 This document represents the consensus of the Crypto Forum Research Group
 (CFRG). It has received review from CFRG participants, including review during
 Research Group Last Call, and an additional review by the CFRG Crypto Review
-Panel. It is also informed by experience from multiple independent
-implementations
+Panel ({{PANEL-FEEDBACK}}). It is also informed by experience from multiple
+independent implementations.
 
 ## Change Log
 


### PR DESCRIPTION
This adopts a suggestion to make the consensus-level statement more detailed.

I also added a link to the CFRG Crypto Review Panel feedback reference in a separate commit, I'm not sure if we should add this or skip it. FWIW, note that once we remove the change log, all existing uses of this reference will be deleted.